### PR TITLE
Introduce --debug flag

### DIFF
--- a/bin/source
+++ b/bin/source
@@ -95,8 +95,15 @@ message="Rebuild for Garden Linux."
 version=
 version_suffix=gardenlinux~dev
 
+
 dir="$(mktemp -d)"
-trap 'cd / && rm -rf "$dir"' EXIT
+if [ -z "${gl_package_build_debug+x}" ]; then
+  trap 'cd / && rm -rf "$dir"' EXIT
+else
+  trap 'echo $dir' EXIT
+  echo "Linux sources are located in:"
+  echo "\t$dir"
+fi
 
 mkdir "$dir/src"
 

--- a/bin/source
+++ b/bin/source
@@ -101,7 +101,7 @@ if [ -z "${gl_package_build_debug+x}" ]; then
   trap 'cd / && rm -rf "$dir"' EXIT
 else
   trap 'echo $dir' EXIT
-  echo "Linux sources are located in:"
+  echo "Package sources are located in:"
   echo "\t$dir"
 fi
 

--- a/build
+++ b/build
@@ -10,6 +10,7 @@ skip_source=
 skip_binary=
 build=binary
 build_dep_dir=
+gl_package_build_debug=
 
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -37,6 +38,10 @@ while [ $# -gt 0 ]; do
 			build_dep_dir="$(realpath "$2")"
 			shift 2
 			;;
+		--debug)
+			gl_package_build_debug=true
+			shift
+			;;
 		*)
 			break
 			;;
@@ -63,7 +68,12 @@ if [ -n "$build_dep_dir" ]; then
 fi
 
 if [ -z "$skip_source" ]; then
-	podman run --security-opt seccomp=unconfined --arch "$arch" --rm "${mount_opts[@]}" -w "/opt/package_build/workdir" "$container" /opt/package_build/bin/source
+  if [ -z "$gl_package_build_debug" ]; then
+	  podman run --security-opt seccomp=unconfined --arch "$arch" --rm "${mount_opts[@]}" -w "/opt/package_build/workdir" "$container" /opt/package_build/bin/source
+  else
+    echo "Starting package build container without --rm"
+	  podman run --security-opt seccomp=unconfined --arch "$arch" "${mount_opts[@]}" -w "/opt/package_build/workdir" -e gl_package_build_debug=true "$container" /opt/package_build/bin/source
+  fi
 fi
 if [ -z "$skip_binary" ]; then
 	podman run --security-opt seccomp=unconfined --arch "$arch" --rm "${mount_opts[@]}" -w "/opt/package_build/workdir" "$container" /opt/package_build/bin/binary "$build"


### PR DESCRIPTION
* by default the pkg build container execute a single script, and the container will be removed after execution. The new "--debug" flag makes sure that the container is not removed and the workingdir for creating the sources are not removed on completion or on error

**What this PR does / why we need it**:
* if we want to create patches, we need to prepare the source folder of the package and perform some manual tasks on the sources. See https://github.com/gardenlinux/package-build/pull/4 

Fixes #3 

**Special notes for your reviewer**:
You may want to cherry-pick the commit [10a0c29](https://github.com/gardenlinux/package-build/pull/6/commits/10a0c29cb99c6394c9e481a5b6d6b64107d83d58) into this PR: https://github.com/gardenlinux/package-build/pull/4


