### PR TITLE
apt_src should download same src as candidate

### DIFF
--- a/bin/source
+++ b/bin/source
@@ -20,6 +20,14 @@ auto_decompress() (
 	esac
 )
 
+
+# Usage:
+# apt_src [--ignore-orig] <package_name>[=<version>]
+#
+# Downloads and extracts the source files of a Debian package.
+# - With <package_name>=<version>, fetches the specific version.
+# - With --ignore-orig, skips processing the original source archive (*.orig.tar.*).
+# If no version is provided, it downloads the candidate version.
 apt_src() (
 	ignore_orig=false
 	if [ "$1" = "--ignore-orig" ]; then

--- a/bin/source
+++ b/bin/source
@@ -31,7 +31,17 @@ apt_src() (
 	trap 'cd / && rm -rf "$tmp_dir"' EXIT
 	cd "$tmp_dir"
 
-	apt-get source --only-source --download-only "$1"
+	# if the src repo provides multiple sources for the same package
+	# download the src with the same version as the candidate
+	if [[ "$1" = *=* ]]; then
+		# specific version requested, do nothing
+		pkg="$1"
+	else
+		candidate=$(apt-cache policy "$1" | grep Candidate | cut -d: -f 2 | tr -d "[:blank:]")
+		pkg="${1}=${candidate}"
+	fi
+
+	apt-get source --only-source --download-only "$pkg"
 
 	orig=(*.orig.tar.*)
 	if [ -n "${orig[*]}" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
When multiple versions of the same package are available via a src repository, _apt_src_ should download the src package with the same version as the candidate.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
