### PR TITLE
Trim the suffix for binNMU

### DIFF
--- a/bin/source
+++ b/bin/source
@@ -49,7 +49,7 @@ apt_src() (
 		candidate=""
 		for p in $(apt-cache showsrc "$1" | grep Binary | sed 's/Binary: //' | tr -d "," | tr '[:blank:]' '\n' | sort | uniq); do
 			if candidate=$(apt-cache policy "$p"); then
-				candidate=$(apt-cache policy "$p" | grep Candidate | cut -d: -f 2- | tr -d "[:blank:]")
+				candidate=$(apt-cache policy "$p" | grep Candidate | cut -d: -f 2- | tr -d "[:blank:]" | sed 's/+b[0-9]\+$//')
 				break
 			fi
 		done


### PR DESCRIPTION
**What this PR does / why we need it**:
The suffix "+b[0-9]\+" should be trimmed when calculating the proper version for _apt_src_.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**: