### PR TITLE
Filter out micro-deb (udeb) when determining candidate

### DIFF
--- a/bin/source
+++ b/bin/source
@@ -47,7 +47,7 @@ apt_src() (
 	else
 		# source package name might not have any installable candidates, so check the candidate version via one of the provided packages
 		candidate=""
-		for p in $(apt-cache showsrc "$1" | grep Binary | sed 's/Binary: //' | tr -d "," | tr '[:blank:]' '\n' | sort | uniq); do
+		for p in $(apt-cache showsrc "$1" | grep Binary | sed 's/Binary: //' | tr -d "," | tr '[:blank:]' '\n' | sort | uniq | grep -v -- -udeb); do
 			if candidate=$(apt-cache policy "$p"); then
 				candidate=$(apt-cache policy "$p" | grep Candidate | cut -d: -f 2- | tr -d "[:blank:]" | sed 's/+b[0-9]\+$//')
 				break


### PR DESCRIPTION
**What this PR does / why we need it**:
Filter our micro-deb (udebs) from the list of provided packages when determining the candidate as they might not be available.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:

