### PR TITLE
Make architecture configurable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ on:
       force-arm-build:
         type: boolean
         default: false
+      arch:
+        type: string
+        default: '["amd64", "arm64"]'
 jobs:
   source:
     runs-on: ubuntu-latest
@@ -93,9 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64
-          - arm64
+        arch: ${{ fromJSON(inputs.arch) }}
     steps:
       - if: matrix.arch == 'amd64'
         run: |
@@ -138,14 +139,16 @@ jobs:
           path: .build
   release:
     runs-on: ubuntu-latest
-    needs: [ source, binary ]
+    needs: [source, binary]
     if: ${{ ! needs.source.outputs.skip_release }}
     steps:
       - uses: actions/download-artifact@v4
+        if: contains(fromJson(inputs.arch), 'amd64')
         with:
           name: binary-amd64
           path: .build
       - uses: actions/download-artifact@v4
+        if: contains(fromJson(inputs.arch), 'arm64')
         with:
           name: binary-arm64
           path: .build


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes the architecture variable configurable. Since we would like to skip the ARM64 builds.