### PR TITLE
Remove xform from tar in git_src as it breaks symlinks

### DIFF
--- a/bin/source
+++ b/bin/source
@@ -82,10 +82,10 @@ apt_src() (
 git_src() (
 	tmp_dir="$(mktemp -d)"
 	trap 'cd / && rm -rf "$tmp_dir"' EXIT
-
-	git clone --depth 1 --recurse-submodules "$@" "$tmp_dir"
-	cd "$tmp_dir"
-	git ls-files --recurse-submodules -z | tar --create --xform s:^:_/: --null --files-from - | tee "$dir/orig.tar" | tar --extract --strip-components 1 --directory "$dir/src"
+	git clone --depth 1 --recurse-submodules "$@" "$tmp_dir/src"
+	mkdir "$tmp_dir/_"
+	git -C "$tmp_dir/src" ls-files --recurse-submodules -z | tar --directory "$tmp_dir/src" --create --null --files-from - | tar --extract --directory "$tmp_dir/_"
+	tar --create --directory "$tmp_dir" _ | tee "$dir/orig.tar" | tar --extract --strip-components 1 --directory "$dir/src"
 )
 
 import_src() (


### PR DESCRIPTION
**What this PR does / why we need it**:
When using _git_src_ and the git repo contains relative symlinks, because of using _xform_ with tar, the symlinks in _orig.tar_ are going to be broken.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**: