### PR TITLE
Set arm64 label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ on:
         default: ubuntu-latest
       runs-on-arm64:
         type: string
-        default: ubuntu-latest-arm
+        default: ubuntu-24.04-arm
       force-arm-build:
         type: boolean
         default: false


### PR DESCRIPTION
Not sure but I think the `-latest` labels are not available anymore, cf: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/
