### PR TITLE
List build artefacts in release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,14 +168,15 @@ jobs:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -x
           ls -lah .build
           RELEASE_NOTES=$(mktemp)
           echo "created by GitHub actions run [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" > $RELEASE_NOTES
           echo "" >> $RELEASE_NOTES
           echo "Files in this release:" >> $RELEASE_NOTES
-          echo "```" >> $RELEASE_NOTES
+          echo '```' >> $RELEASE_NOTES
           find .build -type f -exec basename {} \; | sort >> $RELEASE_NOTES
-          echo "```" >> $RELEASE_NOTES
+          echo '```' >> $RELEASE_NOTES
 
           pkg="${{ needs.source.outputs.pkg }}"
           version="${{ needs.source.outputs.version }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,6 @@ jobs:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -x
           ls -lah .build
           RELEASE_NOTES=$(mktemp)
           echo "created by GitHub actions run [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" > $RELEASE_NOTES

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ls -lah .build
+          RELEASE_NOTES=$(mktemp)
+          echo "created by GitHub actions run [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" > $RELEASE_NOTES
+          echo "" >> $RELEASE_NOTES
+          echo "Files in this release:" >> $RELEASE_NOTES
+          echo "```" >> $RELEASE_NOTES
+          find .build -type f -exec basename {} \; | sort >> $RELEASE_NOTES
+          echo "```" >> $RELEASE_NOTES
+
           pkg="${{ needs.source.outputs.pkg }}"
           version="${{ needs.source.outputs.version }}"
           tar -C .build -cv . | xz | split --bytes=1G --suffix-length=4 --numeric-suffix - build.tar.xz.
-          gh release create "$version" --latest=${{ inputs.latest }} --verify-tag --title "${pkg}_${version}" --notes "created by GitHub actions run [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" build.tar.xz.*
+          gh release create "$version" --latest=${{ inputs.latest }} --verify-tag --title "${pkg}_${version}" --notes-file $RELEASE_NOTES build.tar.xz.*


### PR DESCRIPTION
This PR adds a list of build artefacts to the release notes. This is useful because since we pack the files, you can only see the tarballs in github's file browser.

See an example of what this looks like here: https://github.com/fwilhe/package-mksh/releases/tag/59c-39gl0

<img width="906" alt="Screenshot 2025-01-30 at 16 54 21" src="https://github.com/user-attachments/assets/a053b80a-5549-4cdd-ba64-a553565706e6" />
