### PR TITLE
Print SHA256 sums for release files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,9 @@ jobs:
           echo "" >> $RELEASE_NOTES
           echo "Files in this release:" >> $RELEASE_NOTES
           echo '```' >> $RELEASE_NOTES
-          find .build -type f -exec basename {} \; | sort >> $RELEASE_NOTES
+          pushd .build
+          find . -type f -exec sha256sum {} \; >> $RELEASE_NOTES
+          popd
           echo '```' >> $RELEASE_NOTES
 
           pkg="${{ needs.source.outputs.pkg }}"


### PR DESCRIPTION
Based on #18, this PR also prints the SHA256 sum of the build artefacts. Not sure if anyone really needs that but I think it is good practice to allow checking the files if needed.

<img width="1257" alt="Screenshot 2025-01-31 at 09 06 26" src="https://github.com/user-attachments/assets/46b131cc-9c8f-4aff-96b3-c0be75cdf4ff" />
