### PR TITLE
maintainer doc

### DIFF
--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -13,8 +13,7 @@ Along the series of steps, we will introduce rules in the correct context, which
 | [Rule 1](#rule-1-package-git-repositories-must-be-named-accordingly) | Package git repositories must be named accordingly     |
 | [Rule 2](#rule-2-git-branches-of-package-repositories-must-be-named-accordingly) | Git branches of package repositories must be named accordingly |
 | [Rule 3](#rule-3-one-shot-build-dependency-repositories-must-start-with-bp-package) | One-shot build dependency repositories must start with bp-package |
-| [Rule 4](#rule-4-for-existing-debian-packages-get-debian-folder-from-garden-linux-snapshot-apt-repo)
- | For existing debian packages, get debian folder from Garden Linux snapshot apt repo                               |
+| [Rule 4](#rule-4-for-existing-debian-packages-get-debian-folder-from-garden-linux-snapshot-apt-repo) | For existing debian packages, get debian folder from Garden Linux snapshot apt repo |
 | [Rule 5](#rule-5-create-debian-folder-in-package-repo-only-if-debian-package-does-not-exist) | Create `debian/` folder in package repo only if Debian package does not exist |
 | [Rule 6](#rule-6-get-upstream-source-from-upstream-git) | Get upstream source from upstream git                   |
 | [Rule 7](#rule-7-patching-the-patches) | Patching the patches |

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -1,0 +1,133 @@
+# Maintainer Guide 
+
+
+# Naming Conventions 
+
+
+## Repository Naming 
+
+
+Rule: 
+```
+package-<package-source>
+```
+- must start with package- 
+- <package-source> must be the name of the source package as it is defined in debian
+   - exception: if package does not exist in debian 
+
+
+## Branch Naming
+
+Convention: 
+- `main`: builds against latest Garden Linux environment
+- `rel-<MAJOR>`: builds against `<MAJOR>` version of Garden Linux. 
+- `fix/*`, `feat/*`, `other/*`: are allowed to indicate that the branch is not used for   
+
+# Package build process 
+
+Overview of steps to make a package for Garden Linux:
+```
+1. prepare the package source
+2. make source package
+3. make binary package(s)
+4. test binary package(s)
+5. handover to repo build 
+```
+
+We will walk through each step in detail below.
+
+
+## Prepare the package Source
+
+The source to create a package consists of three parts. 
+The **upstream source code** + the **debian/ folder** + **Garden Linux patches**
+
+### Get debian/ folder
+
+The debian folder contains patches, configurations and rules to make and install the software. For more details about the required content of that debian folder, please read [debian documentation](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html).
+
+To create a Garden Linux package, we also need a **debian/ folder** including all the required files. In the following we define how we **SHOULD** get the debian folder, depending on the case:
+
+
+!RULE!
+
+If there exists a debian package, we must get the **debian/ folder** from salsa git repository, and use git tags to retrieve the corresponding version. 
+
+The **debian/ folder** used by debian packages are in version control and publicly accessible via the [salsa GitLab instance](https://salsa.debian.org/public) 
+
+
+!RULE! 
+
+If there does **NOT** exist a debian package, we must define the **debian/ folder** ourself and check it in our `package-` repository. 
+
+
+
+### Get upstream source  
+
+!RULE! 
+If available, get source from upstream git repository. 
+
+We **MUST** watch upstream git repository automatically, and automatically trigger pipelines to build and test new upstream versions without waiting for a debian maintainer to upgrade salsa. 
+
+For that, we use a scan tooling based on debian's uscan. Rules for this tool are defined per package in `debian/watch`, and include what target upstream repo to watch, and what to watch including what semversion changes should be pulled (e.g. only patchlevel).
+
+:> [!WARNING]
+> Guide on how to define these `debian/watch` rules is to be done!
+
+### Garden Linux Patches 
+
+Garden Linux Patches are applied on top of debian patches. 
+
+
+!RULE! 
+
+Patching the patches. We consider the debian/patches folder as source, and changes wen make to debian/patches are done and tracked via patches. 
+
+:> [!WARNING]
+> please see patching guide --- insert link here --- 
+
+!RULE! 
+
+Upstream patches are appended to debian/patches/series and patched into debian/patches folder. 
+
+
+# Make source package 
+A source package contains all the necessary files to build the binaries, and will be used as input by the next step [Make binary package](##Make-binary-package). 
+
+A definition of a debian source package can be found [here](https://wiki.debian.org/Packaging/SourcePackage).
+
+
+The central gardenlinux/package-build repo contains reusable actions, that are used to automatically perform this step. For reference, see that reusable action [here](https://github.com/gardenlinux/package-build/blob/621c4c8f530a93884f7b9a4dfc348a50a2d19aa5/.github/workflows/build.yml#L29)
+
+
+
+# Make binary package 
+
+Input for this stage is a debian source package created by the previous stage.
+The central gardenlinux/package-build repo contains reusable actions, that are used to automatically perform this step, as well. 
+
+# Test binary package 
+
+TBD
+
+# Handover to repo build 
+
+## Daily release 
+Packages are uploaded to GitHub Release Page. A daily scheduled gardenlinux/repo action collects all latest releases and creates a new apt repository based on latest packages. 
+
+## Patch release 
+Packages for patch releases are also uploaded to the GitHub Release page, but must be manually selected in the gardenlinux/repo to be included for a certain patch release apt repository.  
+
+
+# Notes 
+- Building the package 
+   - Build environments 
+   - Backport environment 
+    - Package Backports 
+        - build environment for backports 
+            - https://github.com/gardenlinux/repo-debian-snapshot
+    - handling null releases (#2736)
+- Build Dependency Management 
+    - override build dependencies 
+    - use default build dependencies
+- Testing Packages (#2735)

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -12,7 +12,7 @@ Along the series of steps, we will introduce rules in the correct context, which
 |-------------|-------------------------------------------------------|
 | [Rule 1](#rule-1-package-git-repositories-must-be-named-accordingly) | Package git repositories must be named accordingly     |
 | [Rule 2](#rule-2-git-branches-of-package-repositories-must-be-named-accordingly) | Git branches of package repositories must be named accordingly |
-| [Rule 3](#rule-3-one---shot-build-dependency-repositories-must-start-with-bp---package) | One-shot backport repositories must start with bp-package |
+| [Rule 3](#rule-3-one-shot-build-dependency-repositories-must-start-with-bp-package) | One-shot backport repositories must start with bp-package |
 | [Rule 4](#rule-4-get-source-from-salsa) | Get source from salsa                                    |
 | [Rule 5](#rule-5-create-debian-folder-in-package-repo-only-if-debian-package-does-not-exist) | Create `debian/` folder in package repo only if Debian package does not exist |
 | [Rule 6](#rule-6-get-upstream-source-from-upstream-git) | Get upstream source from upstream git                   |

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -118,14 +118,6 @@ In the following we define how we **SHOULD** get the debian folder, depending on
 | Package available in debian testing | get debian folder from out apt snapshot | yes | systemd |
 | Package not available in debian testing, but in salsa | get debian folder from salsa | yes | our selected linux LTS |
 
-We have two conflicting targets
-1. Get latest patches from debian automatically
-2. Reliable and streamlined package builds 
-
-If we force Garden Linux packages to get debian folder only from apt-src, then we are unaffected from git history inconsistencies (i.e. modified git tags).
-If we allow Garden Linux packages to get debian folder from salsa, then we could benefit from debian patches as long as debian maintains that version.
-
-Therefore, the Maintainer needs to decide, but the recommended standard way is to base on apt-src, but there may be exceptions.
 
 #### Rule 4: Recommended way of getting debian folder is from snapshot apt-src repo
 Get debian/ Folder from those snapshots, as described below

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -12,7 +12,7 @@ Along the series of steps, we will introduce rules in the correct context, which
 |-------------|-------------------------------------------------------|
 | [Rule 1](#rule-1-package-git-repositories-must-be-named-accordingly) | Package git repositories must be named accordingly     |
 | [Rule 2](#rule-2-git-branches-of-package-repositories-must-be-named-accordingly) | Git branches of package repositories must be named accordingly |
-| [Rule 3](#rule-3-one-shot-backport-repositories-must-start-with-bp-package) | One-shot backport repositories must start with bp-package |
+| [Rule 3](#rule-3-one---shot-build-dependency-repositories-must-start-with-bp---package) | One-shot backport repositories must start with bp-package |
 | [Rule 4](#rule-4-get-source-from-salsa) | Get source from salsa                                    |
 | [Rule 5](#rule-5-create-debian-folder-in-package-repo-only-if-debian-package-does-not-exist) | Create `debian/` folder in package repo only if Debian package does not exist |
 | [Rule 6](#rule-6-get-upstream-source-from-upstream-git) | Get upstream source from upstream git                   |

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -3,11 +3,10 @@
 
 # Naming Conventions 
 
-
 ## Repository Naming 
 
 
-Rule: 
+### Rule 1: package git repositories must be named accordingly
 ```
 package-<package-source>
 ```
@@ -16,7 +15,7 @@ package-<package-source>
    - exception: if package does not exist in debian 
 
 
-## Branch Naming
+### Rule 2: git branches of package repositories must be named accordingly 
 
 Convention: 
 - `main`: builds against latest Garden Linux environment
@@ -49,23 +48,21 @@ The debian folder contains patches, configurations and rules to make and install
 To create a Garden Linux package, we also need a **debian/ folder** including all the required files. In the following we define how we **SHOULD** get the debian folder, depending on the case:
 
 
-!RULE!
-
-If there exists a debian package, we must get the **debian/ folder** from salsa git repository, and use git tags to retrieve the corresponding version. 
+> !RULE!
+> If there exists a debian package, we must get the **debian/ folder** from salsa git repository, and use git tags to retrieve the corresponding version. 
 
 The **debian/ folder** used by debian packages are in version control and publicly accessible via the [salsa GitLab instance](https://salsa.debian.org/public) 
 
 
-!RULE! 
-
-If there does **NOT** exist a debian package, we must define the **debian/ folder** ourself and check it in our `package-` repository. 
+> !RULE! 
+> If there does **NOT** exist a debian package, we must define the **debian/ folder** ourself and check it in our `package-` repository. 
 
 
 
 ### Get upstream source  
 
-!RULE! 
-If available, get source from upstream git repository. 
+> !RULE! 
+> If available, get source from upstream git repository. 
 
 We **MUST** watch upstream git repository automatically, and automatically trigger pipelines to build and test new upstream versions without waiting for a debian maintainer to upgrade salsa. 
 
@@ -79,16 +76,16 @@ For that, we use a scan tooling based on debian's uscan. Rules for this tool are
 Garden Linux Patches are applied on top of debian patches. 
 
 
-!RULE! 
-
+**RULE 1.1
 Patching the patches. We consider the debian/patches folder as source, and changes wen make to debian/patches are done and tracked via patches. 
 
 :> [!WARNING]
 > please see patching guide --- insert link here --- 
 
 !RULE! 
-
+``` 
 Upstream patches are appended to debian/patches/series and patched into debian/patches folder. 
+```
 
 
 # Make source package 

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -49,7 +49,7 @@ How to do a backport package build is described [here](https://github.com/garden
 Branch types: 
 - `main`: builds against latest Garden Linux environment
 - `rel-<MAJOR>`: builds against `<MAJOR>` version of Garden Linux. 
-- `fix/*`, `feat/*`, `other/*`: are allowed to indicate that the branch is not used for   
+- `fix/*`, `feat/*`, `other/*`: are allowed to indicate that the branch is used temporarily for work in progress   
 
 ## Use Case 3: Create build dependency package with Garden Linux pipelines
 

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -107,6 +107,14 @@ The debian folder contains patches, configurations and rules to make and install
 
 To create a Garden Linux package, we also need a **debian/ folder** including all the required files. In the following we define how we **SHOULD** get the debian folder, depending on the case:
 
+🏗️⚠️ This section is currently being added and reworked ⚠️🚧
+case 1: salsa maintains debian folder + a modified copy of the upstream sources
+case 2: salsa maintains only debian folder
+case 3: package does not exist in salsa
+case 4: salsa is outdated
+🏗️⚠️ This section is currently being added and reworked ⚠️🚧
+
+
 
 #### Rule 4: For existing debian packages, get debian folder from Garden Linux snapshot apt repo
 Get debian/ Folder from those snapshots, as described below

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -13,7 +13,8 @@ Along the series of steps, we will introduce rules in the correct context, which
 | [Rule 1](#rule-1-package-git-repositories-must-be-named-accordingly) | Package git repositories must be named accordingly     |
 | [Rule 2](#rule-2-git-branches-of-package-repositories-must-be-named-accordingly) | Git branches of package repositories must be named accordingly |
 | [Rule 3](#rule-3-one-shot-build-dependency-repositories-must-start-with-bp-package) | One-shot build dependency repositories must start with bp-package |
-| [Rule 4](#rule-4-get-source-from-salsa) | Get source from salsa                                    |
+| [Rule 4](#rule-4-for-existing-debian-packages-get-debian-folder-from-garden-linux-snapshot-apt-repo)
+ | For existing debian packages, get debian folder from Garden Linux snapshot apt repo                               |
 | [Rule 5](#rule-5-create-debian-folder-in-package-repo-only-if-debian-package-does-not-exist) | Create `debian/` folder in package repo only if Debian package does not exist |
 | [Rule 6](#rule-6-get-upstream-source-from-upstream-git) | Get upstream source from upstream git                   |
 | [Rule 7](#rule-7-patching-the-patches) | Patching the patches |

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -99,7 +99,9 @@ We will walk through each step in detail below.
 ## Prepare the package Source
 
 The source to create a package consists of three parts. 
-The **upstream source code** + the **debian/ folder** + **Garden Linux patches**
+1. The **upstream source code**
+2. The **debian/ folder**
+3. **Garden Linux patches**
 
 
 ### Get debian/ folder

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -101,11 +101,22 @@ We will walk through each step in detail below.
 The source to create a package consists of three parts. 
 The **upstream source code** + the **debian/ folder** + **Garden Linux patches**
 
+
 ### Get debian/ folder
 
 The debian folder contains patches, configurations and rules to make and install the software. For more details about the required content of that debian folder, please read [debian documentation](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html).
 
 To create a Garden Linux package, we also need a **debian/ folder** including all the required files. In the following we define how we **SHOULD** get the debian folder, depending on the case:
+
+
+#### Case 1: No debian package available 
+
+In this case, we must manually maintain the **debian/ folder**.
+
+
+#### Case 2: salsa maintains only debian folder
+In this case, we can get the **debian folder** from our debian apt snapshot.
+
 
 🏗️⚠️ This section is currently being added and reworked ⚠️🚧
 

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -1,12 +1,28 @@
 # Maintainer Guide 
 
+This guide is written for Garden Linux maintainers, explaining with context the steps required for creating a package for Garden Linux. 
 
-# Naming Conventions 
+
+
+## Overview
+| Rule Number | Description                                             |
+|-------------|-------------------------------------------------------|
+| [Rule 1](#rule-1-package-git-repositories-must-be-named-accordingly) | Package git repositories must be named accordingly     |
+| [Rule 2](#rule-2-git-branches-of-package-repositories-must-be-named-accordingly) | Git branches of package repositories must be named accordingly |
+| [Rule 3](#rule-3-one-shot-backport-repositories-must-start-with-bp-package) | One-shot backport repositories must start with bp-package |
+| [Rule 4](#rule-4-get-source-from-salsa) | Get source from salsa                                    |
+| [Rule 5](#rule-5-create-debian-folder-in-package-repo-only-if-debian-package-does-not-exist) | Create `debian/` folder in package repo only if Debian package does not exist |
+| [Rule 6](#rule-6-get-upstream-source-from-upstream-git) | Get upstream source from upstream git                   |
+| [Rule 7](#rule-7-patching-the-patches) | Patching the patches |
+| [Rule 8](#rule-8-append-to-debian-patches) | Append to debian patches        |
+
+
+# Git Repository conventions
 
 ## Repository Naming 
 
 
-### Rule 1: package git repositories must be named accordingly
+### Rule 1: Package git repositories must be named accordingly
 ```
 package-<package-source>
 ```
@@ -15,12 +31,19 @@ package-<package-source>
    - exception: if package does not exist in debian 
 
 
-### Rule 2: git branches of package repositories must be named accordingly 
+### Rule 2: Git branches of package repositories must be named accordingly
 
 Convention: 
 - `main`: builds against latest Garden Linux environment
 - `rel-<MAJOR>`: builds against `<MAJOR>` version of Garden Linux. 
 - `fix/*`, `feat/*`, `other/*`: are allowed to indicate that the branch is not used for   
+
+
+### Rule 3: One-shot backport repositories must start with bp-package
+
+Package repositories only required as a dependency for a backported package must start with bp-package-*.
+
+Please note that the bp-package-* is only included in the targeted package-*  backport.
 
 # Package build process 
 
@@ -48,44 +71,40 @@ The debian folder contains patches, configurations and rules to make and install
 To create a Garden Linux package, we also need a **debian/ folder** including all the required files. In the following we define how we **SHOULD** get the debian folder, depending on the case:
 
 
-> !RULE!
-> If there exists a debian package, we must get the **debian/ folder** from salsa git repository, and use git tags to retrieve the corresponding version. 
-
+#### Rule 4: Get source from salsa
+If there exists a debian package, we must get the **debian/ folder** from salsa git repository, and use git tags to retrieve the corresponding version. 
 The **debian/ folder** used by debian packages are in version control and publicly accessible via the [salsa GitLab instance](https://salsa.debian.org/public) 
 
 
-> !RULE! 
-> If there does **NOT** exist a debian package, we must define the **debian/ folder** ourself and check it in our `package-` repository. 
+## Rule 5: Create `debian/` folder in package repo only if Debian package does not exist
 
+If there does **NOT** exist a debian package, we must define the **debian/ folder** ourself and check it in our `package-` repository. 
 
 
 ### Get upstream source  
 
-> !RULE! 
-> If available, get source from upstream git repository. 
-
 We **MUST** watch upstream git repository automatically, and automatically trigger pipelines to build and test new upstream versions without waiting for a debian maintainer to upgrade salsa. 
-
 For that, we use a scan tooling based on debian's uscan. Rules for this tool are defined per package in `debian/watch`, and include what target upstream repo to watch, and what to watch including what semversion changes should be pulled (e.g. only patchlevel).
-
 :> [!WARNING]
 > Guide on how to define these `debian/watch` rules is to be done!
+
+## Rule 6: Get upstream source from upstream git
+To enable automatic upstream version tracking, get source from upstream git repository. 
+This means do NOT use apt source packages, do NOT use patches to update to a version.
 
 ### Garden Linux Patches 
 
 Garden Linux Patches are applied on top of debian patches. 
 
-
-**RULE 1.1
-Patching the patches. We consider the debian/patches folder as source, and changes wen make to debian/patches are done and tracked via patches. 
-
 :> [!WARNING]
 > please see patching guide --- insert link here --- 
 
-!RULE! 
-``` 
-Upstream patches are appended to debian/patches/series and patched into debian/patches folder. 
-```
+#### Rule 7: Patching the patches 
+Patching the patches. We consider the debian/patches folder as source, and changes wen make to debian/patches are done and tracked via patches. 
+
+
+#### Rule 8: Append to `debian/patches`
+Upstream patches are appended to debian/patches/series and patched as new files into the debian/patches folder. 
 
 
 # Make source package 
@@ -95,7 +114,6 @@ A definition of a debian source package can be found [here](https://wiki.debian.
 
 
 The central gardenlinux/package-build repo contains reusable actions, that are used to automatically perform this step. For reference, see that reusable action [here](https://github.com/gardenlinux/package-build/blob/621c4c8f530a93884f7b9a4dfc348a50a2d19aa5/.github/workflows/build.yml#L29)
-
 
 
 # Make binary package 

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -108,10 +108,12 @@ The debian folder contains patches, configurations and rules to make and install
 To create a Garden Linux package, we also need a **debian/ folder** including all the required files. In the following we define how we **SHOULD** get the debian folder, depending on the case:
 
 🏗️⚠️ This section is currently being added and reworked ⚠️🚧
-case 1: salsa maintains debian folder + a modified copy of the upstream sources
-case 2: salsa maintains only debian folder
-case 3: package does not exist in salsa
-case 4: salsa is outdated
+
+- case 1: salsa maintains debian folder + a modified copy of the upstream sources
+- case 2: salsa maintains only debian folder
+- case 3: package does not exist in salsa
+- case 4: salsa is outdated
+
 🏗️⚠️ This section is currently being added and reworked ⚠️🚧
 
 

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -106,30 +106,26 @@ The **upstream source code** + the **debian/ folder** + **Garden Linux patches**
 
 The debian folder contains patches, configurations and rules to make and install the software. For more details about the required content of that debian folder, please read [debian documentation](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html).
 
-To create a Garden Linux package, we also need a **debian/ folder** including all the required files. In the following we define how we **SHOULD** get the debian folder, depending on the case:
+To create a Garden Linux package, we also need a **debian/ folder** including all the required files.
+In the following we define how we **SHOULD** get the debian folder, depending on the case:
 
 
-#### Case 1: No debian package available 
+| Case | Recommended way to get debian folder | Debian Security Tracking? | Example | 
+| ---- | ----------- | -------------------------------------------------- | ------- |
+| Package not available in debian at all | manually maintain the **debian/ folder**. | not possible | metalbond |
+| Package available in debian testing | get debian folder from out apt snapshot | yes | systemd |
+| Package not available in debian testing, but in salsa | get debian folder from salsa | yes | our selected linux LTS |
 
-In this case, we must manually maintain the **debian/ folder**.
+We have two conflicting targets
+1. Get latest patches from debian automatically
+2. Reliable and streamlined package builds 
 
+If we force Garden Linux packages to get debian folder only from apt-src, then we are unaffected from git history inconsistencies (i.e. modified git tags).
+If we allow Garden Linux packages to get debian folder from salsa, then we could benefit from debian patches as long as debian maintains that version.
 
-#### Case 2: salsa maintains only debian folder
-In this case, we can get the **debian folder** from our debian apt snapshot.
+Therefore, the Maintainer needs to decide, but the recommended standard way is to base on apt-src, but there may be exceptions.
 
-
-🏗️⚠️ This section is currently being added and reworked ⚠️🚧
-
-- case 1: salsa maintains debian folder + a modified copy of the upstream sources
-- case 2: salsa maintains only debian folder
-- case 3: package does not exist in salsa
-- case 4: salsa is outdated
-
-🏗️⚠️ This section is currently being added and reworked ⚠️🚧
-
-
-
-#### Rule 4: For existing debian packages, get debian folder from Garden Linux snapshot apt repo
+#### Rule 4: Recommended way of getting debian folder is from snapshot apt-src repo
 Get debian/ Folder from those snapshots, as described below
 
 The helper script [apt_src](https://github.com/gardenlinux/package-build/blob/621c4c8f530a93884f7b9a4dfc348a50a2d19aa5/bin/source#L31C1-L31C8) must be used in prepare_source like this:

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -22,7 +22,7 @@ This guide is written for Garden Linux maintainers, explaining with context the 
 ## Repository Naming 
 
 
-### Rule 1: Package git repositories must be named accordingly
+#### Rule 1: Package git repositories must be named accordingly
 ```
 package-<package-source>
 ```
@@ -31,7 +31,7 @@ package-<package-source>
    - exception: if package does not exist in debian 
 
 
-### Rule 2: Git branches of package repositories must be named accordingly
+#### Rule 2: Git branches of package repositories must be named accordingly
 
 Convention: 
 - `main`: builds against latest Garden Linux environment
@@ -39,7 +39,7 @@ Convention:
 - `fix/*`, `feat/*`, `other/*`: are allowed to indicate that the branch is not used for   
 
 
-### Rule 3: One-shot backport repositories must start with bp-package
+#### Rule 3: One-shot backport repositories must start with bp-package
 
 Package repositories only required as a dependency for a backported package must start with bp-package-*.
 
@@ -76,7 +76,7 @@ If there exists a debian package, we must get the **debian/ folder** from salsa 
 The **debian/ folder** used by debian packages are in version control and publicly accessible via the [salsa GitLab instance](https://salsa.debian.org/public) 
 
 
-## Rule 5: Create `debian/` folder in package repo only if Debian package does not exist
+#### Rule 5: Create `debian/` folder in package repo only if Debian package does not exist
 
 If there does **NOT** exist a debian package, we must define the **debian/ folder** ourself and check it in our `package-` repository. 
 
@@ -88,7 +88,7 @@ For that, we use a scan tooling based on debian's uscan. Rules for this tool are
 :> [!WARNING]
 > Guide on how to define these `debian/watch` rules is to be done!
 
-## Rule 6: Get upstream source from upstream git
+#### Rule 6: Get upstream source from upstream git
 To enable automatic upstream version tracking, get source from upstream git repository. 
 This means do NOT use apt source packages, do NOT use patches to update to a version.
 

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -1,7 +1,7 @@
 # Maintainer Guide 
 
 This guide is written for Garden Linux maintainers, explaining the steps required for creating a package for Garden Linux.
-Along the series of steps, we will introduce rules in the correct context, which are outlined in the chapter [Overview of Rules](#overview-of-rules).
+Along the series of steps, we will introduce rules in the correct context, which are outlined in the table presented in the [Overview of Rules](#overview-of-rules).
 
 > [!NOTE]
 > The overall Garden Linux release process is described in a Garden Linux Maintainer internal document [here](https://github.com/gardenlinux/process/blob/main/release.md).
@@ -20,18 +20,29 @@ Along the series of steps, we will introduce rules in the correct context, which
 | [Rule 8](#rule-8-append-to-debian-patches) | Append to debian patches        |
 
 
-# Create a new package git repository
+# Use Cases 
 
+
+| Use Case                           | Description                                      |
+|-------------------------------------|------------------------------------------------|
+| [Use Case 1](#use-case-1-build-package-with-garden-linux-pipelines) | Build package with Garden Linux pipelines       |
+| [Use Case 2](#use-case-2-build-backport-package-with-garden-linux-pipelines) | Build Backport package with Garden Linux pipelines |
+| [Use Case 3](#use-case-3-create-build-dependency-package-with-garden-linux-pipelines) | Create build dependency package with Garden Linux pipelines |
+| [Use Case 4](#use-case-4-local-builds) | Local builds                                    |
+
+## Use Case 1: Build package with Garden Linux pipelines
+How to do a regular package build is described [here](https://github.com/gardenlinux/package-build/blob/main/README.md#github-action-build).
 
 #### Rule 1: Package git repositories must be named accordingly
 ```
 package-<package-source>
 ```
-- must start with package- 
+- must start with `package-` 
 - `<package-source>` must be the name of the source package as it is defined in debian
    - exception: if package does not exist in debian 
 
-# Create a backport branch for a package git repository
+## Use Case 2: Build Backport package with Garden Linux pipelines
+How to do a backport package build is described [here](https://github.com/gardenlinux/package-build/blob/main/README.md#patch-releases--backporting).
 
 #### Rule 2: Git branches of package repositories must be named accordingly
 
@@ -40,7 +51,7 @@ Branch types:
 - `rel-<MAJOR>`: builds against `<MAJOR>` version of Garden Linux. 
 - `fix/*`, `feat/*`, `other/*`: are allowed to indicate that the branch is not used for   
 
-# Create a one-shot build-dependency git repository 
+## Use Case 3: Create build dependency package with Garden Linux pipelines
 
 In the case when a package `ABC` requires a build dependency `XYZ` in a certain version or with a certain patch applied, we use the bp-package repositories,
 which are one-shot build dependency packages. 
@@ -62,11 +73,16 @@ jobs:
 ```
 
 #### Rule 3: One-shot build dependency repositories must start with bp-package
-
 Package repositories only required as a dependency for a backported package must start with bp-package-*.
 
+## Use Case 4: Local builds
+Building packages locally is explained [here](https://github.com/gardenlinux/package-build/blob/main/README.md#local-package-build), no rules apply.
+ 
 
 # Package build process 
+
+The package build process is described in further detail in this chapter in addition to the short guide in the [README.md](https://github.com/gardenlinux/package-build/blob/main/README.md).
+
 
 Overview of steps to make a package for Garden Linux:
 ```

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -1,10 +1,13 @@
 # Maintainer Guide 
 
-This guide is written for Garden Linux maintainers, explaining with context the steps required for creating a package for Garden Linux. 
+This guide is written for Garden Linux maintainers, explaining the steps required for creating a package for Garden Linux.
+Along the series of steps, we will introduce rules in the correct context, which are outlined in the chapter [Overview of Rules](#overview-of-rules).
+
+> [!NOTE]
+> The overall Garden Linux release process is described in a Garden Linux Maintainer internal document [here](https://github.com/gardenlinux/process/blob/main/release.md).
 
 
-
-## Overview
+## Overview of Rules
 | Rule Number | Description                                             |
 |-------------|-------------------------------------------------------|
 | [Rule 1](#rule-1-package-git-repositories-must-be-named-accordingly) | Package git repositories must be named accordingly     |

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -108,12 +108,17 @@ The debian folder contains patches, configurations and rules to make and install
 To create a Garden Linux package, we also need a **debian/ folder** including all the required files. In the following we define how we **SHOULD** get the debian folder, depending on the case:
 
 
-#### Rule 4: Get source from salsa
-If there exists a debian package, we must get the **debian/ folder** from salsa git repository, and use git tags to retrieve the corresponding version. 
-The **debian/ folder** used by debian packages are in version control and publicly accessible via the [salsa GitLab instance](https://salsa.debian.org/public) 
+#### Rule 4: For existing debian packages, get debian folder from Garden Linux snapshot apt repo
+Get debian/ Folder from those snapshots, as described below
 
+The helper script [apt_src](https://github.com/gardenlinux/package-build/blob/621c4c8f530a93884f7b9a4dfc348a50a2d19aa5/bin/source#L31C1-L31C8) must be used in prepare_source like this:
+```
+apt_src --ignore_orig <source_package_name> 
+```
+> [!NOTE]
+> All Debian packages from testing are mirrored daily in a Garden Linux snapshot apt repository, if a source package is missing in a snapshot, salsa may be used to get a debian/ folder. 
 
-#### Rule 5: Create `debian/` folder in package repo only if Debian package does not exist
+#### Rule 5: For packages not existing in debian at all, create `debian/` folder in package- git repo
 
 If there does **NOT** exist a debian package, we must define the **debian/ folder** ourself and check it in our `package-` repository. 
 
@@ -138,12 +143,15 @@ Garden Linux Patches are applied on top of debian patches.
 > please see patching guide --- insert link here --- 
 
 #### Rule 7: Patching the patches 
-Patching the patches. We consider the debian/patches folder as source, and changes wen make to debian/patches are done and tracked via patches. 
+We consider the debian/patches folder as source, and changes to debian/patches are done and tracked via patches. 
 
 
 #### Rule 8: Append to `debian/patches`
-Upstream patches are appended to debian/patches/series and patched as new files into the debian/patches folder. 
+Patches for upstream source are put in folder `upstream_patches` and applied with helper function [import_upstream_patches](https://github.com/gardenlinux/package-build/blob/621c4c8f530a93884f7b9a4dfc348a50a2d19aa5/bin/source#L122)
+This helper function copies the patches to debian/patches and appends them to debian/patches/series 
 
+> [!NOTE]
+> This allows us to conviniently import and maintain patches from upstream (e.g. cherry-pick an upstream commit on a different branch that fixes a CVE).
 
 # Make source package 
 A source package contains all the necessary files to build the binaries, and will be used as input by the next step [Make binary package](##Make-binary-package). 

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -12,7 +12,7 @@ Along the series of steps, we will introduce rules in the correct context, which
 |-------------|-------------------------------------------------------|
 | [Rule 1](#rule-1-package-git-repositories-must-be-named-accordingly) | Package git repositories must be named accordingly     |
 | [Rule 2](#rule-2-git-branches-of-package-repositories-must-be-named-accordingly) | Git branches of package repositories must be named accordingly |
-| [Rule 3](#rule-3-one-shot-build-dependency-repositories-must-start-with-bp-package) | One-shot backport repositories must start with bp-package |
+| [Rule 3](#rule-3-one-shot-build-dependency-repositories-must-start-with-bp-package) | One-shot build dependency repositories must start with bp-package |
 | [Rule 4](#rule-4-get-source-from-salsa) | Get source from salsa                                    |
 | [Rule 5](#rule-5-create-debian-folder-in-package-repo-only-if-debian-package-does-not-exist) | Create `debian/` folder in package repo only if Debian package does not exist |
 | [Rule 6](#rule-6-get-upstream-source-from-upstream-git) | Get upstream source from upstream git                   |


### PR DESCRIPTION
**What this PR does / why we need it**:
Guide and rule book written for Garden Linux maintainers, explaining the package-build maintenance tasks while introducing rules in the correct context. 

**Which issue(s) this PR fixes**:
- closes https://github.com/gardenlinux/gardenlinux/issues/2736
- closes https://github.com/gardenlinux/gardenlinux/issues/2821
- closes https://github.com/gardenlinux/gardenlinux/issues/2731


**Special notes for your reviewer**:
* Will invite to a meeting to go through the package-build process described in this document. 