### PR TITLE
Change date format to follow iso 8601 format

### DIFF
--- a/bin/source
+++ b/bin/source
@@ -136,7 +136,7 @@ import_upstream_patches() (
 )
 
 handle_leave_artifacts_exit()(
-  output_run_dir="$output/run_$(date +"%d-%m-%Y_%H:%M")"
+  output_run_dir="$output/run_$(date -u +"%Y-%m-%dT%H-%M-%SZ")"
   cd / 
   mv "$dir" $output_run_dir 
   mv $output_run_dir/src $output_run_dir/a 


### PR DESCRIPTION
yyyy-mm-dd is a format that is sorted properly when sorting alphabetically, and it should be understandable the same way regardless of local ways to write a date.

Replace colons with dashes for the time as colons might cause problems on windows.
