### PR TITLE
Backporting a Package Already in nightly Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,27 @@ version_suffix=gl0~bp1443
 This will cause the package build to fetch all actual source file from the upstream openssl repo on github.com, while taking the debian folder from the apt source package.
 In the case that there are compatibility issues between the apt source debian folder and the new upstream source some patches might need to be added (see the apply_patches function in the source script).
 
-##
+#### Example: Backporting a Package Already in nightly Releases
 
+Suppose you want to backport a package (for example, `gnutls28` version 3.8.9-3) that was previously available in Debian testing and is therefore present in a GardenLinux nightly snapshot. In this case, you can use the following approach in your `prepare_source` script:
+
+```
+pkg=gnutls28
+version_orig=3.8.9
+version="${version_orig}-3"
+version_suffix="gl1+bp1592"
+
+# Option 1: Use a known snapshot timestamp
+# snapshot_timestamp=1754597610
+
+# Option 2: Search through Garden Linux nightly versions
+start_gl_version="1982" # Start searching from this GL nightly version and search back 30 versions
+snapshot_timestamp=$(pkg_version_in_gl_version "$pkg" "$version" "$start_gl_version" 30)
+
+# Get sources from snapshot timestamp
+snapshot_src "$pkg" "$snapshot_timestamp"
+```
+
+This approach tells the package build system to retrieve the `.orig.tar` and `.debian.tar` source archives for the specified version from the most recent available GardenLinux snapshot (starting from `start_gl_version` and searching backwards). It then rebuilds the package exactly as it was in that nightly release.
+
+##

--- a/bin/source
+++ b/bin/source
@@ -136,20 +136,20 @@ import_upstream_patches() (
 )
 
 # Usage:
-# pkg_version_in_gl_version <package_name> <version> <start_version> [max_versions_back] [base_url]
+# pkg_version_in_gl_version <package_name> <version> <start_version> [max_versions] [base_url]
 #
 # Searches for a snapshot by searching through Garden Linux versions (e.g., 1882.0, 1881.0, etc.).
 # - <package_name>: The source package name to search for
 # - <version>: The exact version to find (e.g., "3.8.9-3")
 # - <start_version>: Starting GL version to search from (e.g., "1882")
-# - [max_versions_back]: Maximum number of versions to search backwards (default: 30)
+# - [max_versions]: Maximum number of versions to search forwards (default: 30)
 # - [base_url]: Optional base URL (defaults to https://packages.gardenlinux.io)
 # Returns the "gl:$version" if found, or exits with error if not found.
 pkg_version_in_gl_version() (
 	pkg="$1"
 	version="$2"
 	start_version="$3"
-	max_versions_back="${4:-30}"
+	max_versions="${4:-30}"
 	base_url="${5:-https://packages.gardenlinux.io}"
 
 	tmp_dir="$(mktemp -d)"
@@ -164,7 +164,7 @@ pkg_version_in_gl_version() (
 	minor=0
 
 	versions_checked=0
-	while [ "$versions_checked" -lt "$max_versions_back" ]; do
+	while [ "$versions_checked" -lt "$max_versions" ]; do
 		current_version="${major}.${minor}"
 		sources_url="${base_url}/gardenlinux/dists/${current_version}/main/source/Sources.gz"
 		echo "Checking GL version $current_version at $sources_url..." >&2
@@ -204,25 +204,25 @@ pkg_version_in_gl_version() (
 			echo "GL version $current_version not found or not accessible" >&2
 		fi
 
-		major=$((major - 1))
+		major=$((major + 1))
 
 		versions_checked=$((versions_checked + 1))
 	done
 
-	echo "Error: No snapshot found containing package '$pkg' version '$version' in the last $max_versions_back GL versions from $start_version" >&2
+	echo "Error: No snapshot found containing package '$pkg' version '$version' in the last $max_versions GL versions from $start_version" >&2
 	exit 1
 )
 
 # Usage:
-# snapshot_src <package_name> <snapshot_timestamp> [base_url]
+# snapshot_src <package_name> <snapshot> [base_url]
 #
 # Downloads and extracts source files from a Garden Linux snapshot repository.
 # - <package_name>: The source package name to download
-# - <snapshot_timestamp>: The snapshot timestamp to use
+# - <snapshot>: The snapshot timestamp or GL version to use (e.g. "1754597610" or "gl:1982")
 # - [base_url]: Optional base URL (defaults to https://packages.gardenlinux.io)
 snapshot_src() (
 	pkg="$1"
-	snapshot_timestamp="$2"
+	snapshot="$2"
 	base_url="${3:-https://packages.gardenlinux.io}"
 
 	command -v curl >/dev/null || apt-get install --no-install-recommends -y curl >&2
@@ -230,14 +230,14 @@ snapshot_src() (
 	command -v xz >/dev/null || apt-get install --no-install-recommends -y xz-utils >&2
 
 	# Check if this is a GL version (format: gl:XXXX.X)
-	if [[ "$snapshot_timestamp" =~ ^gl: ]]; then
-		gl_version="${snapshot_timestamp#gl:}"
+	if [[ "$snapshot" =~ ^gl: ]]; then
+		gl_version="${snapshot#gl:}"
 		sources_url="${base_url}/gardenlinux/dists/${gl_version}/main/source/Sources.gz"
 		echo "Using GL version $gl_version" >&2
 	else
 		# Regular timestamp-based snapshot
-		sources_url="${base_url}/debian-snapshot/dists/${snapshot_timestamp}/main/source/Sources.gz"
-		echo "Using snapshot timestamp $snapshot_timestamp" >&2
+		sources_url="${base_url}/debian-snapshot/dists/${snapshot}/main/source/Sources.gz"
+		echo "Using snapshot timestamp $snapshot" >&2
 	fi
 	if ! curl -sSLf "$sources_url" | gunzip >Sources; then
 		echo "Error: Failed to download Sources file from $sources_url" >&2
@@ -293,7 +293,7 @@ snapshot_src() (
 
 	for file in $files; do
 		# Check if this is a GL version to use the correct URL structure
-		if [[ "$snapshot_timestamp" =~ ^gl: ]]; then
+		if [[ "$snapshot" =~ ^gl: ]]; then
 			file_url="${base_url}/gardenlinux/${directory}/${file}"
 		else
 			file_url="${base_url}/${directory}/${file}"

--- a/bin/source
+++ b/bin/source
@@ -130,19 +130,210 @@ import_upstream_patches() (
 
 			mkdir -p "$(dirname "$dir/src/debian/patches/$patch")"
 			cp "$patch_dir/$patch" "$dir/src/debian/patches/$patch"
-			echo "$patch" >> "$dir/src/debian/patches/series"
-		done < "$patch_dir/series"
+			echo "$patch" >>"$dir/src/debian/patches/series"
+		done <"$patch_dir/series"
 	fi
 )
 
-handle_leave_artifacts_exit()(
-  output_run_dir="$output/run_$(date -u +"%Y-%m-%dT%H-%M-%SZ")"
-  cd / 
-  mv "$dir" $output_run_dir 
-  mv $output_run_dir/src $output_run_dir/a 
-  cp -r $output_run_dir/a $output_run_dir/b
+# Usage:
+# pkg_version_in_gl_version <package_name> <version> <start_version> [max_versions_back] [base_url]
+#
+# Searches for a snapshot by searching through Garden Linux versions (e.g., 1882.0, 1881.0, etc.).
+# - <package_name>: The source package name to search for
+# - <version>: The exact version to find (e.g., "3.8.9-3")
+# - <start_version>: Starting GL version to search from (e.g., "1882")
+# - [max_versions_back]: Maximum number of versions to search backwards (default: 30)
+# - [base_url]: Optional base URL (defaults to https://packages.gardenlinux.io)
+# Returns the "gl:$version" if found, or exits with error if not found.
+pkg_version_in_gl_version() (
+	pkg="$1"
+	version="$2"
+	start_version="$3"
+	max_versions_back="${4:-30}"
+	base_url="${5:-https://packages.gardenlinux.io}"
+
+	tmp_dir="$(mktemp -d)"
+	trap 'cd / && rm -rf "$tmp_dir"' EXIT
+
+	command -v curl >/dev/null || apt-get install --no-install-recommends -y curl >&2
+	command -v gunzip >/dev/null || apt-get install --no-install-recommends -y gzip >&2
+
+	echo "Searching for package '$pkg' version '$version' starting from GL version $start_version..." >&2
+
+	major=$(echo "$start_version" | cut -d. -f1)
+	minor=0
+
+	versions_checked=0
+	while [ "$versions_checked" -lt "$max_versions_back" ]; do
+		current_version="${major}.${minor}"
+		sources_url="${base_url}/gardenlinux/dists/${current_version}/main/source/Sources.gz"
+		echo "Checking GL version $current_version at $sources_url..." >&2
+
+		if curl -sSLf "$sources_url" -o "${tmp_dir}/sources_${current_version}.gz" 2>/dev/null; then
+			echo "Found GL version $current_version, checking for package..." >&2
+
+			if gunzip -c "${tmp_dir}/sources_${current_version}.gz" >"${tmp_dir}/sources_${current_version}.txt" 2>/dev/null; then
+				if grep -q "^Package: $pkg$" "${tmp_dir}/sources_${current_version}.txt"; then
+					pkg_version=$(awk -v pkg="$pkg" '
+						/^Package: / { if ($2 == pkg) { in_package = 1; next } else { in_package = 0; next } }
+						in_package && /^Version: / { print $2; exit }
+					' "${tmp_dir}/sources_${current_version}.txt")
+					if [ -n "$pkg_version" ]; then
+						echo "GL version $current_version has package '$pkg' version '$pkg_version'" >&2
+
+						if [ "$pkg_version" = "$version" ]; then
+							echo "✓ MATCH: Found GL version $current_version with package '$pkg' version '$version'" >&2
+							rm -f "${tmp_dir}/sources_${current_version}.gz" "${tmp_dir}/sources_${current_version}.txt"
+							echo "gl:${current_version}"
+							return 0
+						fi
+					else
+						echo "GL version $current_version has package '$pkg' but could not determine version" >&2
+					fi
+				else
+					echo "GL version $current_version does not contain package '$pkg'" >&2
+				fi
+
+				rm -f "${tmp_dir}/sources_${current_version}.txt"
+			else
+				echo "ERROR: Failed to decompress Sources file for GL version $current_version" >&2
+			fi
+
+			rm -f "${tmp_dir}/sources_${current_version}.gz"
+		else
+			echo "GL version $current_version not found or not accessible" >&2
+		fi
+
+		major=$((major - 1))
+
+		versions_checked=$((versions_checked + 1))
+	done
+
+	echo "Error: No snapshot found containing package '$pkg' version '$version' in the last $max_versions_back GL versions from $start_version" >&2
+	exit 1
 )
 
+# Usage:
+# snapshot_src <package_name> <snapshot_timestamp> [base_url]
+#
+# Downloads and extracts source files from a Garden Linux snapshot repository.
+# - <package_name>: The source package name to download
+# - <snapshot_timestamp>: The snapshot timestamp to use
+# - [base_url]: Optional base URL (defaults to https://packages.gardenlinux.io)
+snapshot_src() (
+	pkg="$1"
+	snapshot_timestamp="$2"
+	base_url="${3:-https://packages.gardenlinux.io}"
+
+	command -v curl >/dev/null || apt-get install --no-install-recommends -y curl >&2
+	command -v gunzip >/dev/null || apt-get install --no-install-recommends -y gzip >&2
+	command -v xz >/dev/null || apt-get install --no-install-recommends -y xz-utils >&2
+
+	# Check if this is a GL version (format: gl:XXXX.X)
+	if [[ "$snapshot_timestamp" =~ ^gl: ]]; then
+		gl_version="${snapshot_timestamp#gl:}"
+		sources_url="${base_url}/gardenlinux/dists/${gl_version}/main/source/Sources.gz"
+		echo "Using GL version $gl_version" >&2
+	else
+		# Regular timestamp-based snapshot
+		sources_url="${base_url}/debian-snapshot/dists/${snapshot_timestamp}/main/source/Sources.gz"
+		echo "Using snapshot timestamp $snapshot_timestamp" >&2
+	fi
+	if ! curl -sSLf "$sources_url" | gunzip >Sources; then
+		echo "Error: Failed to download Sources file from $sources_url" >&2
+		exit 1
+	fi
+
+	package_section=$(awk -v pkg="$pkg" '
+		/^Package: / {
+			if ($2 == pkg) {
+				in_package = 1;
+				next
+			} else {
+				in_package = 0;
+				next
+			}
+		}
+		in_package && /^$/ && package_started {
+			exit
+		}
+		in_package {
+			package_started = 1;
+			print
+		}
+	' Sources)
+
+	if [ -z "$package_section" ]; then
+		echo "Error: Package '$pkg' not found in snapshot" >&2
+		exit 1
+	fi
+
+	directory=$(echo "$package_section" | grep "^Directory:" | cut -d' ' -f2)
+
+	if [ -z "$directory" ]; then
+		echo "Error: Directory not found for package '$pkg'" >&2
+		exit 1
+	fi
+
+	# Extract the list of source files from the package section
+	files_list=$(echo "$package_section" | awk '
+		/^Files:/ {in_files=1; next}
+		in_files && /^[^ ]/ {exit}
+		in_files && /^ / {print $3}
+	')
+	# Filter for .orig and .debian tarballs, ignore .asc signatures, and ensure uniqueness.
+	files=$(echo "$files_list" | grep -F "${pkg}_" | grep -E '\.(orig|debian)\.tar\.' | grep -v '\.asc$' | sort -u)
+
+	if [ -z "$files" ]; then
+		echo "Error: No source files found for package '$pkg'" >&2
+		exit 1
+	fi
+
+	mkdir -p "$dir/src"
+
+	for file in $files; do
+		# Check if this is a GL version to use the correct URL structure
+		if [[ "$snapshot_timestamp" =~ ^gl: ]]; then
+			file_url="${base_url}/gardenlinux/${directory}/${file}"
+		else
+			file_url="${base_url}/${directory}/${file}"
+		fi
+		case "$file" in
+		*.orig.tar.* | *.debian.tar.*)
+			case "$file" in
+			*.xz) decompressor="xz -d" ;;
+			*.gz) decompressor="gzip -d" ;;
+			*.bz2) decompressor="bzip2 -d" ;;
+			esac
+			tar_opts="--directory \"$dir/src\""
+			# Only strip components for orig tarballs
+			[[ "$file" == *.orig.tar.* ]] && tar_opts="--strip-components 1 $tar_opts"
+
+			if [[ "$file" == *.orig.tar.* ]]; then
+				# For orig files, save to orig.tar and extract
+				if ! curl -Lf "$file_url" | $decompressor | tee "$dir/orig.tar" | eval tar xf - $tar_opts; then
+					echo "Error: Failed to download/extract $file" >&2
+					exit 1
+				fi
+			else
+				# For debian files, just extract
+				if ! curl -Lf "$file_url" | $decompressor | eval tar xf - $tar_opts; then
+					echo "Error: Failed to download/extract $file" >&2
+					exit 1
+				fi
+			fi
+			;;
+		esac
+	done
+)
+
+handle_leave_artifacts_exit() (
+	output_run_dir="$output/run_$(date -u +"%Y-%m-%dT%H-%M-%SZ")"
+	cd /
+	mv "$dir" $output_run_dir
+	mv $output_run_dir/src $output_run_dir/a
+	cp -r $output_run_dir/a $output_run_dir/b
+)
 
 email="contact@gardenlinux.io"
 maintainer="Garden Linux Builder"


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows easily backporting packages already available in nightly releases using two new functions `pkg_version_in_gl_version()` and `snapshot_src`.
It adds documentation examples for the default and for corner cases (no sources in salsa).

#### Example: Backporting a Package Already in nightly Releases

Suppose you want to backport a package (for example, `jq` version `1.8.1`) that was previously available in Debian testing and is therefore tracked in debian's salsa repository. In this case, you can use the following approach in your `prepare_source` script:

```
pkg=jq
version_orig=1.8.1
version="$version_orig-3"
# look up in salsa what the correct branch is
git_src -b "debian/$version" https://salsa.debian.org/debian/jq.git

version_suffix=gl0+bp1877
```

This approach tells the package build system to simply checkout the debian salsa repo in a specific branch. It then rebuilds the package exactly as it was in that nightly release.

#### Example: Backporting a Package Already in nightly Releases - last resort - missing salsa sources

> [!Warning]
> Use this method only as a last resort if the source code (or parts of it) is not available in debian salsa or upstream sources differ a lot.
> In all other cases, this method is discouraged.

Suppose you want to backport a package (for example, `sqlite3` version `3.46.1`) that was previously available in Debian testing, but is not—or only partially—available in Debian's salsa repository. However, the package is still present in our daily repository snapshots, which are also used for our nightly releases. In this situation, you can use the following approach in your `prepare_source` script:

```
pkg=sqlite3
version_orig=3.46.1
version="${version_orig}-7"
version_suffix="gl0+bp1877"

# Option 1: Use a known snapshot timestamp
# snapshot=1754316590

# Option 2: Search through Garden Linux nightly versions
snapshot_gl_version="1943" # Start searching from this GL nightly version and search forward 30 versions
snapshot=$(pkg_version_in_gl_version "$pkg" "$version" "$snapshot_gl_version" 30)

# Get sources from snapshot
snapshot_src "$pkg" "$snapshot_timestamp"
```

> [!Note]
> The debian snapshots can be a useful a hint since when GardenLinux snapshots contain a certain package version.
> e.g. goto https://snapshot.debian.org/package/sqlite3/3.46.1-7/ look for the date `2025-07-26` and but that into
> `bin/garden-version --major 2025-07-26`, you will get `1943` as a candidate version for `snapshot_gl_version`.

This approach tells the package build system to retrieve the `.orig.tar` and `.debian.tar` source archives for the specified version from the earliest available Garden
