### PR TITLE
Skip tagging, binary and release if skip file exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,12 @@ jobs:
         name: check version
         run: |
           ls -lah .build
+          if [ -f .build/skip_everything ]; then
+            echo "skipping everything..."
+            echo skip_build=true >> "$GITHUB_OUTPUT"
+            echo skip_release=true >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           pkg="$(awk -F ': ' '$1 == "Source" { print $2 }' < .build/*.dsc)"
           version="$(awk -F ': ' '$1 == "Version" { print $2 }' < .build/*.dsc | tr '~' '+')"
           version="${version#*:}"


### PR DESCRIPTION
**What this PR does / why we need it**:
If _skip_everything_ file exists in the _.build_ directory then the tagging, binary build and release should be skipped.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**: