### PR TITLE
Add possibilty to separate build and publish steps in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
       release:
         type: boolean
         default: false
+      publish_release:
+        type: boolean
+        default: true
       latest:
         type: boolean
         default: ${{ github.ref == 'refs/heads/main' }}
@@ -157,7 +160,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [source, binary]
-    if: ${{ ! needs.source.outputs.skip_release }}
+    if: ${{ ! needs.source.outputs.skip_release }} && inputs.publish_release
     steps:
       - uses: actions/download-artifact@v4
         if: contains(fromJson(inputs.arch), 'amd64')


### PR DESCRIPTION
This introduces the `publish_release` input boolean flag to the GitHub
Action to add the possibility to separate the build and publish steps in
the CI workflow. When set to `false`, the action will only perform the
build step without publishing the release. The default remains `true` to
publish the release
