### PR TITLE
Do not tag when the release is not published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
             !.git
       - id: tag
         name: check version
+        if: inputs.publish_release
         run: |
           ls -lah .build
           if [ -f .build/skip_everything ]; then


### PR DESCRIPTION
In case a release is not published by setting `publish_release: false`
then we should not tag it either.

fixes: fbdfe6b5
