### PR TITLE
Fix: Add :Z flag to mount opts for selinux compatiblity

### DIFF
--- a/build
+++ b/build
@@ -64,12 +64,12 @@ if [ -z "$container" ]; then
 fi
 
 mount_opts=(
-	-v "$src_dir/bin:/opt/package_build/bin"
-	-v "$dir:/opt/package_build/workdir"
+	-v "$src_dir/bin:/opt/package_build/bin:Z"
+	-v "$dir:/opt/package_build/workdir:Z"
 )
 
 if [ -n "$build_dep_dir" ]; then
-	mount_opts+=(-v "$build_dep_dir:/opt/package_build/workdir/build_dep")
+	mount_opts+=(-v "$build_dep_dir:/opt/package_build/workdir/build_dep:Z")
 fi
 
 if [ -n "$edit" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

Add SELinux volume labels `:Z` to podman mounts for compatiblity between rootless `podman` and SELinux.

On Linux systems with SELinux, rootless podman builds can fail with:

```bash
/opt/package_build/bin/source: Permission denied
```

This occurs even when file-permissions are correct and the user has access to the files on the host.

When a filesystem is mounted with the `seclabel` option, which is common on SELinux enabled versions of Fedora, RHEL, CentOS and openSUSE, files have [SELinux security labels](https://www.man7.org/linux/man-pages/man8/SELinux.8.html) like `user_home_t` which protects them from unauthorized access. When `podman` mounts these files into a container, the container process itself runs with context `container_t` but the mounted files remain their original security label `user_home_t`. The SELinux policy denies `container_t` processes access to `user_home_t` files, resulting in the `"Permission Denied"` error.

This affects any Linux distro with SELinux enabled when running unpriviledged `podman` (and `docker`).

Adding the `:Z` suffix to the volume mounts, tells `podman` to relabel the mounted files with something along the lines of `container_file_t`. 

This is purely a fix for modern Linux distributions requiring SELinux. On any other OS without SELinux enabled (like Windows, MacOS or any Linux distribution using AppArmor), the `:Z` suffix is ignored.

[Docker Docs](https://docs.docker.com/engine/storage/bind-mounts/#configure-the-selinux-label)
[Podman Docs](https://docs.podman.io/en/latest/markdown/podman-run.1.html#volume-v-source-volume-options)
[SELinux Manpage](https://www.man7.org/linux/man-pages/man8/SELinux.8.html)
[Red Hat Docs](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/selinux_users_and_administrators_guide/sect-security-enhanced_linux-working_with_selinux-selinux_contexts_labeling_files)

**Which issue(s) this PR fixes**:
Fixes: https://github.com/gardenlinux/package-build/issues/36
