### PR TITLE
[Docs] Merge `docs-ng` into `main` for `docs-ng`

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,74 @@
+name: Documentation Quality Check
+
+on:
+  pull_request:
+    branches: [main, docs-ng]
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'docs/**'
+  push:
+    branches: [main, docs-ng]
+    paths:
+      - 'docs/**'
+
+jobs:
+  docs-checks:
+    # Skip checks on closed PRs (only need the notification)
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
+    uses: gardenlinux/docs-ng/.github/workflows/docs-checks.yml@main
+    with:
+      override-repo: ${{ github.event.repository.name }}
+      override-ref: ${{ github.head_ref || github.ref_name }}
+      override-commit: ${{ github.event.pull_request.head.sha || github.sha }}
+
+  notify-docs-ng:
+    name: Notify docs-ng
+    needs: [docs-checks]
+    runs-on: ubuntu-24.04
+    # Only notify for PR events (not push events which lack PR context)
+    # Run after checks pass for open PRs, OR immediately for merged PRs
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      (
+        (github.event.action == 'closed' && github.event.pull_request.merged == true) ||
+        (github.event.action != 'closed' && needs.docs-checks.result == 'success')
+      )
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
+          repositories: docs-ng
+
+      - name: Send repository dispatch to docs-ng
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const isMergedPR = context.payload.action === 'closed' &&
+                               context.payload.pull_request.merged === true;
+
+            // For merged PRs, use the base branch (the branch it was merged into)
+            // For open PRs, use the head branch (feature branch)
+            const ref = isMergedPR
+              ? context.payload.pull_request.base.ref
+              : context.payload.pull_request.head.ref;
+
+            await github.rest.repos.createDispatchEvent({
+              owner: 'gardenlinux',
+              repo: 'docs-ng',
+              event_type: 'docs-pr',
+              client_payload: {
+                repo: '${{ github.event.repository.name }}',
+                pr_number: `${context.payload.pull_request.number}`,
+                commit_sha: isMergedPR
+                  ? context.payload.pull_request.merge_commit_sha
+                  : context.payload.pull_request.head.sha,
+                ref: ref,
+                event: isMergedPR ? 'merged' : 'pr_success'
+              }
+            });
+            core.info('Repository dispatch sent to docs-ng');

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -111,7 +111,7 @@ Since prepare_source is invoked directly in the package-build pipeline as step i
 
 ### Get debian/ folder
 
-The debian folder contains patches, configurations and rules to make and install the software. For more details about the required content of that debian folder, please read [debian documentation](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html).
+The debian folder contains patches, configurations and rules to make and install the software. For more details about the required content of that debian folder, read [debian documentation](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html).
 
 To create a Garden Linux package, we also need a **debian/ folder** including all the required files.
 In the following we define how we **SHOULD** get the debian folder, depending on the case:
@@ -161,7 +161,7 @@ git_src --branch <BRANCH NAME> <GIT_REPO_URL>
 Garden Linux Patches are applied on top of debian patches. 
 
 > [!WARNING]
-> please see patching guide --- insert link here --- 
+> see patching guide --- insert link here --- 
 
 #### Rule 7: Patching debian patches 
 We consider the debian/patches folder as source, and changes to debian/patches are done and tracked via patches. 
@@ -238,7 +238,7 @@ Packages for patch releases are also uploaded to the GitHub Release page, but mu
 If a package-XYZ build must be excluded in next nightly apt repositories, a so called "NULL release" must be published for package-XYZ. 
 
 > [!IMPORTANT]
-> If you want to remove/archive a package from Garden Linux by creating a null release, please follow this [guide](https://github.com/gardenlinux/repo?tab=readme-ov-file#remove-garden-linux-packages-from-the-repo).
+> If you want to remove/archive a package from Garden Linux by creating a null release, follow this [guide](https://github.com/gardenlinux/repo?tab=readme-ov-file#remove-garden-linux-packages-from-the-repo).
 
 ### What happens under the hood
 The [fetch_releases](https://github.com/gardenlinux/repo/blob/main/fetch_releases) script runs as part of the github actions of gardenlinux/repo. 

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -208,7 +208,7 @@ The central gardenlinux/package-build repo contains reusable actions, that are u
 Input for this stage is a debian source package created by the previous stage.
 The central gardenlinux/package-build repo contains reusable actions, that are used to automatically perform this step, as well. 
 
-You can add a `prepare_binary` script to the package-XYZ repo to additionally perform some preparations before the binary build step is executed. 
+You can add a `prepare_binary` script to the package-XYZ repo to perform additional preparations before the binary build step is executed. 
 You could for example reconfigure debian build profiles, install build dependencies or add some logging flags for debugging.
 
 # Test binary package 

--- a/README.md
+++ b/README.md
@@ -1,156 +1,49 @@
 # Gardenlinux APT repo - package build tools
 
-## Local package build
+This repository provides standardized build scripts for creating new Debian
+packages, GitHub Actions workflows for build automation and documentation for
+local and CI-based package building.
 
-1. clone this repository
-   ```
-   git clone https://github.com/gardenlinux/package-build.git
-   ```
-2. clone the package repository, e.g. *iproute2*
-   ```
-   git clone https://github.com/gardenlinux/package-iproute2.git
-   ```
-3. run `build` from the *package-build* repo with the package repository as argument
-   ```
-   ./package-build/build package-iproute2
-   ```
-   - *optional*: If a package build depends on other custom build packages you can provide the `--build-dependencies` flag with a directory containing the `.deb` files of build-time dependencies
+## Documentation
 
-The build artifacts (`deb` files and others) are placed in a `.build` directory in your package, for example in `./package-iproute2/.build/`.
+To find detailed how-to-guides about the different stages of the package release
+lifecycle, check out
+[our packaging section](https://gardenlinux-docs.netlify.app/how-to/packaging/),
+our documentation on [package sources](https://gardenlinux-docs.netlify.app/explanation/package-sources.html#package-sources)
+or our [packaging rules](https://gardenlinux-docs.netlify.app/reference/packaging-rules.html)
+in [our documentation hub](https://gardenlinux-docs.netlify.app/)
 
-### Build options
+# Community
 
-The `build` script takes arguments which may be used to customize the build.
+To stay up-to-date with recent news about Gardenlinux, subscribe to our mailing
+list:
 
-- `--arch amd64`: Specify the architecture to build
-   - Choices: `amd64` (default), `arm64` 
-- `--source-only`: Only build source archive
-- `--binary-only`: Only build the binary archives
-- `--leave-artifacts`: creates the sources folder and keeps them in a `package-XYZ/output/run_<date_time>` folder of  local `package-XYZ` folder
-- `--build-dependencies`: path to a directory that contains `*.deb` files to be used as build time dependencies
-- `--edit`: spawns a gardenlinux/repo-debian-snapshort container with `package-XYZ/output` mounted, quilt installed and configured.  
+https://lists.neonephos.org/g/gardenlinux-discussion
 
-## GitHub action build
+For updates and statements regarding security issues, we have a security mailing
+list for you:
 
-To build using GitHub actions simply define a job with
+https://lists.neonephos.org/g/gardenlinux-security
 
-```
-uses: gardenlinux/package-build/.github/workflows/build.yml@main
-```
+For embargoed security related topics, this list is for you:
 
-### Job inputs
+https://lists.neonephos.org/g/gardenlinux-security-embargo
 
-The GitHub action jobs accepts various inputs:
+# Contributing
 
-#### `release` (*boolean*)
-Flag if this is a release build.
-If set to `true` this will cause the build job to automatically append `gardenlinux0` as the version suffix and create a GitHub release from the resulting source and binary packages.
+We welcome your contributions to Gardenlinux or any supporting projects.
 
-#### `build_dep` (*string*)
-A list of other GitHub repositories to pull custom build-time dependencies from. In the format `<repo> <tag>`
+To find our more, visit our
+[Contributor Documentation](https://gardenlinux-docs.netlify.app/contributing).
 
-> [!Important]
-> Build-time dependencies between packages are not updated automatically and need to be adjusted manually when needed
+## Licensing
 
-#### `runs-on`, `runs-on-amd64`, `runs-on-arm64` (*string*)
-Specify the GitHub action runner on which to run the job
+Copyright 2025 SAP SE or an SAP affiliate company and GardenLinux contributors.
+Please see our [LICENSE](LICENSE) for copyright and license information.
+Detailed information including third-party components and their
+licensing/copyright information is available
+[via the REUSE tool](https://reuse.software).
 
-### Example
-
-A full github workflow file to build a package and regularly try if a new version should be build looks as follows:
-
-```
-on:
-  push:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *'
-jobs:
-  build:
-    uses: gardenlinux/package-build/.github/workflows/build.yml@main
-    with:
-      release: ${{ github.ref == 'refs/heads/main' }}
-```
-
-### Patch releases / backporting
-
-When running the GitHub action job with `release: true` it automatically creates a new release with version suffix `gardenlinux0`.
-To create a patch release for this version:
-
-1. Check out the release tag and branch off from it
-   ```
-   git fetch --tags
-   git checkout <VERSION>gardenlinux0
-   git branch <VERSION>
-   git checkout <VERSION>
-   ```
-2. Apply modifications or backport patches from main
-3. Increment the version suffix. The GitHub action job which created the `<VERSION>gardenlinux0` tag automatically added a `version_suffix=gardenlinux0` line to the `prepare_source` script. Simply increment this suffix. In certain scenarios you might want to backport this to an older GardenLinux version; in this case you will need to also update the _.container_ file and use the proper one; e.g. _ghcr.io/gardenlinux/repo-debian-snapshot@sha256:3577da968aa41816bf255e189925c6c67df1266effe800a7d0cd66cddc5760ca_ for version 1443.
-4. Push the branch
-   ```
-   git push origin <VERSION>
-   ```
-   If the action is setup to run on `push`, as in the example above, this will trigger the build job to run which detects that this is a new version and thus causes it to be released, setting up the necessary tags and GitHub releases.
-
-#### Example: backport new upstream version not (yet) available on salsa
-
-If we want to, for example, backport openssl 3.1.7 but this version does not exist in debian salsa step 3 of the above instructions would be to set the `prepare_source` script to
-
-```
-version_orig=3.1.7
-version="$version_orig-0"
-git_src --branch "openssl-$version_orig" https://github.com/openssl/openssl.git
-apt_src --ignore-orig openssl
-version_suffix=gl0~bp1443
-```
-
-This will cause the package build to fetch all actual source file from the upstream openssl repo on github.com, while taking the debian folder from the apt source package.
-In the case that there are compatibility issues between the apt source debian folder and the new upstream source some patches might need to be added (see the apply_patches function in the source script).
-
-#### Example: Backporting a Package Already in nightly Releases
-
-Suppose you want to backport a package (for example, `jq` version `1.8.1`) that was previously available in Debian testing and is therefore tracked in debian's salsa repository. In this case, you can use the following approach in your `prepare_source` script:
-
-```
-pkg=jq
-version_orig=1.8.1
-version="$version_orig-3"
-# look up in salsa what the correct branch is
-git_src -b "debian/$version" https://salsa.debian.org/debian/jq.git
-
-version_suffix=gl0+bp1877
-```
-
-This approach tells the package build system to simply checkout the debian salsa repo in a specific branch. It then rebuilds the package exactly as it was in that nightly release.
-
-#### Example: Backporting a Package Already in nightly Releases - last resort - missing salsa sources
-
-> [!Warning]
-> Use this method only as a last resort if the source code (or parts of it) is not available in debian salsa or upstream sources differ a lot.
-> In all other cases, this method is discouraged.
-
-Suppose you want to backport a package (for example, `sqlite3` version `3.46.1`) that was previously available in Debian testing, but is not—or only partially—available in Debian's salsa repository. However, the package is still present in our daily repository snapshots, which are also used for our nightly releases. In this situation, you can use the following approach in your `prepare_source` script:
-
-```
-pkg=sqlite3
-version_orig=3.46.1
-version="${version_orig}-7"
-version_suffix="gl0+bp1877"
-
-# Option 1: Use a known snapshot timestamp
-# snapshot=1754316590
-
-# Option 2: Search through Garden Linux nightly versions
-snapshot_gl_version="1943" # Start searching from this GL nightly version and search forward 30 versions
-snapshot=$(pkg_version_in_gl_version "$pkg" "$version" "$snapshot_gl_version" 30)
-
-# Get sources from snapshot
-snapshot_src "$pkg" "$snapshot_timestamp"
-```
-
-> [!Note]
-> The debian snapshots can be a useful a hint since when GardenLinux snapshots contain a certain package version.
-> e.g. goto https://snapshot.debian.org/package/sqlite3/3.46.1-7/ look for the date `2025-07-26` and but that into
-> `bin/garden-version --major 2025-07-26`, you will get `1943` as a candidate version for `snapshot_gl_version`.
-
-This approach tells the package build system to retrieve the `.orig.tar` and `.debian.tar` source archives for the specified version from the earliest available GardenLinux snapshot (starting from `snapshot_gl_version` and searching forward). It then rebuilds the package exactly as it was in that nightly release.
+<p align="center">
+  <img alt="Bundesministerium für Wirtschaft und Energie (BMWE)-EU funding logo" src="https://apeirora.eu/assets/img/BMWK-EU.png" width="400"/>
+</p>

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To find our more, visit our
 ## Licensing
 
 Copyright 2025 SAP SE or an SAP affiliate company and GardenLinux contributors.
-Please see our [LICENSE](LICENSE) for copyright and license information.
+See our [LICENSE](LICENSE) for copyright and license information.
 Detailed information including third-party components and their
 licensing/copyright information is available
 [via the REUSE tool](https://reuse.software).

--- a/docs/explanation/package-sources.md
+++ b/docs/explanation/package-sources.md
@@ -1,0 +1,62 @@
+---
+title: Package Sources
+description: Learn about different types of Garden Linux Package Sources
+order: 102
+related_topics:
+  - /explanation/release-hierarchy.md
+  - /explanation/packaging.md
+  - /explanation/package-sources.md
+  - /explanation/repo-infrastructure.md
+  - /explanation/os-releases.md
+  - /explanation/semver.md
+  - /how-to/releases/package-releases.md
+  - /how-to/packaging/local-build.md
+  - /how-to/packaging/github-actions.md
+  - /how-to/packaging/creating-packages.md
+  - /how-to/packaging/backporting.md
+  - /how-to/packaging/patching.md
+  - /how-to/packaging/build-dependencies.md
+  - /how-to/packaging/null-releases.md
+  - /reference/packaging-rules.md
+migration_status: "done"
+migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
+migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
+migration_approved: false
+github_org: gardenlinux
+github_repo: package-build
+github_source_path: docs/explanation/package-sources.md
+github_target_path: docs/explanation/package-sources.md
+---
+
+# Package Sources
+
+Garden Linux packages are built using [the `package-build` tools](https://github.com/gardenlinux/package-build).
+
+Each package has its own GitHub repository following the naming convention `package-{package_name}`. These packages are picked up by [the workflows of the 'repo'](https://github.com/gardenlinux/repo).
+
+There are different types of package sources used in Garden Linux:
+
+## Source from Debian
+
+Packages built from Debian sources are used when:
+
+- Applying Garden Linux-specific patches on top of existing Debian packages
+- Rebuilding with a specific build environment (e.g., newer versions of golang, glibc, gcc) when a newer compiler or runtime is needed
+- A package we include was temporarily removed from Debian testing (this happens occasionally and is expected)
+
+## Source from Upstream Project
+
+Packages built from upstream sources are used when:
+
+- Debian does not maintain a package for the software we need
+- Debian maintains only an older version, and we need to create a package for a newer version available in the upstream project
+
+## Native Source
+
+Packages with native sources are used when:
+
+- The source code is developed and maintained by the Garden Linux developers, so Debian does not package it
+
+## Related Topics
+
+<RelatedTopics />

--- a/docs/explanation/package-sources.md
+++ b/docs/explanation/package-sources.md
@@ -57,6 +57,6 @@ Packages with native sources are used when:
 
 - The source code is developed and maintained by the Garden Linux developers, so Debian does not package it
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/explanation/packaging.md
+++ b/docs/explanation/packaging.md
@@ -1,0 +1,96 @@
+---
+title: Packaging
+description: Understand how Garden Linux packages are built and built using the package-build tools
+order: 101
+related_topics:
+  - /explanation/release-hierarchy.md
+  - /explanation/packaging.md
+  - /explanation/package-sources.md
+  - /explanation/repo-infrastructure.md
+  - /explanation/os-releases.md
+  - /explanation/semver.md
+  - /how-to/releases/package-releases.md
+  - /how-to/packaging/local-build.md
+  - /how-to/packaging/github-actions.md
+  - /how-to/packaging/creating-packages.md
+  - /how-to/packaging/backporting.md
+  - /how-to/packaging/patching.md
+  - /how-to/packaging/build-dependencies.md
+  - /how-to/packaging/null-releases.md
+  - /reference/packaging-rules.md
+migration_status: "done"
+migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
+migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
+migration_approved: false
+github_org: gardenlinux
+github_repo: package-build
+github_source_path: docs/explanation/packaging.md
+github_target_path: docs/explanation/packaging.md
+---
+
+# Packaging Ecosystem
+
+This document explains how Garden Linux packages are built using the tools in the `package-build` repository and how they fit into the broader packaging ecosystem.
+
+## Release Hierarchy
+
+Garden Linux uses a [three-tier release hierarchy](/explanation/release-hierarchy.md) to deliver a complete operating system.
+
+This document is about the first tier, the [Packaging](/explanation/packaging).
+
+## Package Build Tools Repository (`package-build`)
+
+The [`package-build`](https://github.com/gardenlinux/package-build) repository provides:
+
+- Standardized build scripts for creating Debian packages
+- GitHub Actions workflows for automated building
+- Common functions and utilities used by all package repositories
+- Documentation for local and CI-based package building
+
+## Source Package Repositories (`package-*`)
+
+Each custom-built package has its own GitHub repository following the naming convention `package-{package_name}` (e.g., `package-containerd`, `package-openssh`). These repositories contain:
+
+- The source code or references to upstream sources
+- Build scripts and configuration
+- Debian packaging files (debian/ directory)
+- Package-specific build instructions
+
+These repositories are built using the tools in the `package-build` repository.
+
+## Package Flow Process Overview
+
+1. **Source Management**: Package source lives in `package-{package_name}` repos
+2. **Building**: Packages are built using tools from `package-build` repo
+   - Can be done locally or via GitHub Actions
+3. **Release Assembly**: Built packages are collected and assembled into APT repositories by the `repo` workflow
+4. **Distribution**: Final APT repository is published and made available to users
+
+## Key Relationships
+
+- Each `package-*` repo declares its build dependencies in its source
+- The `package-build` repo provides common tooling used by all `package-*` repos
+- The [`repo`](https://github.com/gardenlinux/repo) orchestrates the final release by collecting built packages and dependencies
+- Users access packages through the standard APT system pointing to Garden Linux repositories
+
+## Understanding Package Versions
+
+Garden Linux packages typically follow versioning like:
+
+```
+<upstream_version>-<debian_revision>~gardenlinux<sequence>
+```
+
+For example: `1.2.3-1~gardenlinux0`
+
+Where:
+
+- `1.2.3` is the upstream version
+- `-1` is the Debian revision
+- `~gardenlinux0` indicates this is the first Garden Linux rebuild
+
+When creating patch releases or backports, the suffix is incremented (e.g., `~gardenlinux1`, `~gardenlinux2`) or modified for specific use cases (like `~bp1443` for backports).
+
+## Related Topics
+
+<RelatedTopics />

--- a/docs/explanation/packaging.md
+++ b/docs/explanation/packaging.md
@@ -32,7 +32,7 @@ github_target_path: docs/explanation/packaging.md
 
 This document explains how Garden Linux packages are built using the tools in the `package-build` repository and how they fit into the broader packaging ecosystem.
 
-## Release Hierarchy
+## Release hierarchy
 
 Garden Linux uses a [three-tier release hierarchy](/explanation/release-hierarchy.md) to deliver a complete operating system.
 
@@ -58,7 +58,7 @@ Each custom-built package has its own GitHub repository following the naming con
 
 These repositories are built using the tools in the `package-build` repository.
 
-## Package Flow Process Overview
+## Package flow process overview
 
 1. **Source Management**: Package source lives in `package-{package_name}` repos
 2. **Building**: Packages are built using tools from `package-build` repo
@@ -66,14 +66,14 @@ These repositories are built using the tools in the `package-build` repository.
 3. **Release Assembly**: Built packages are collected and assembled into APT repositories by the `repo` workflow
 4. **Distribution**: Final APT repository is published and made available to users
 
-## Key Relationships
+## Key relationships
 
 - Each `package-*` repo declares its build dependencies in its source
 - The `package-build` repo provides common tooling used by all `package-*` repos
 - The [`repo`](https://github.com/gardenlinux/repo) orchestrates the final release by collecting built packages and dependencies
 - Users access packages through the standard APT system pointing to Garden Linux repositories
 
-## Understanding Package Versions
+## Understanding package versions
 
 Garden Linux packages typically follow versioning like:
 
@@ -91,6 +91,6 @@ Where:
 
 When creating patch releases or backports, the suffix is incremented (e.g., `~gardenlinux1`, `~gardenlinux2`) or modified for specific use cases (like `~bp1443` for backports).
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/backporting.md
+++ b/docs/how-to/backporting.md
@@ -34,7 +34,7 @@ This guide covers how to create patch releases and backport packages in Garden L
 
 For foundational knowledge on package creation and repository structure, see the [Packaging Rules](/reference/packaging-rules.md) reference.
 
-## Creating Patch Releases
+## Creating patch releases
 
 When running the GitHub Actions job with `release: true`, it automatically creates a new release with version suffix `gl0` (or `gardenlinux0` in older packages). To create a patch release for this version:
 
@@ -81,9 +81,9 @@ git push origin <VERSION>
 
 If the action is set up to run on `push` (as in the basic example), this will trigger the build job. The job will detect that this is a new version and create the necessary tags and GitHub releases.
 
-## Backporting Examples
+## Backporting examples
 
-### Backporting New Upstream Version Not Available (yet) on Salsa
+### Backporting new upstream version not available (yet) on Salsa
 
 When backporting a version not available (yet) in Debian salsa (e.g., OpenSSL 3.1.7), configure the `prepare_source` script as follows:
 
@@ -97,7 +97,7 @@ version_suffix=gl0~bp1443
 
 This configuration fetches source files from the upstream repository while using the Debian folder from the apt source package. If there are compatibility issues, patches may need to be added using the `apply_patches` function.
 
-### Backporting Package Already in Nightly Releases
+### Backporting package already in nightly releases
 
 For packages available in Debian testing and tracked in salsa (e.g., `jq` version `1.8.1`):
 
@@ -111,7 +111,7 @@ git_src -b "debian/$version" https://salsa.debian.org/debian/jq.git
 version_suffix=gl0+bp1877
 ```
 
-### Backporting Missing Salsa Sources (Last Resort)
+### Backporting missing Salsa sources (last resort)
 
 :::warning
 Use this method only as a last resort when source code is not available in Debian salsa or when upstream sources differ significantly. In all other cases, this method is discouraged.
@@ -140,6 +140,6 @@ snapshot_src "$pkg" "$snapshot_timestamp"
 Debian snapshots can be useful for determining when Garden Linux snapshots contain a certain package version. For example, visit https://snapshot.debian.org/package/sqlite3/3.46.1-7/ to find the date `2025-07-26`, then use `bin/garden-version --major 2025-07-26` to get `1943` as a candidate version for `snapshot_gl_version`.
 :::
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/backporting.md
+++ b/docs/how-to/backporting.md
@@ -1,0 +1,145 @@
+---
+title: Patch Releases and Backporting
+description: Learn how to update and backport Garden Linux Packages
+order: 5
+related_topics:
+  - /explanation/release-hierarchy.md
+  - /explanation/packaging.md
+  - /explanation/package-sources.md
+  - /explanation/repo-infrastructure.md
+  - /explanation/os-releases.md
+  - /explanation/semver.md
+  - /how-to/releases/package-releases.md
+  - /how-to/packaging/local-build.md
+  - /how-to/packaging/github-actions.md
+  - /how-to/packaging/creating-packages.md
+  - /how-to/packaging/backporting.md
+  - /how-to/packaging/patching.md
+  - /how-to/packaging/build-dependencies.md
+  - /how-to/packaging/null-releases.md
+  - /reference/packaging-rules.md
+migration_status: "done"
+migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
+migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
+migration_approved: false
+github_org: gardenlinux
+github_repo: package-build
+github_source_path: docs/how-to/backporting.md
+github_target_path: docs/how-to/packaging/backporting.md
+---
+
+# Patch Releases and Backporting
+
+This guide covers how to create patch releases and backport packages in Garden Linux.
+
+For foundational knowledge on package creation and repository structure, see the [Packaging Rules](/reference/packaging-rules.md) reference.
+
+## Creating Patch Releases
+
+When running the GitHub Actions job with `release: true`, it automatically creates a new release with version suffix `gl0` (or `gardenlinux0` in older packages). To create a patch release for this version:
+
+### 1. Check out the release tag
+
+```bash
+git fetch --tags
+git checkout <VERSION>gl0
+git branch <VERSION>
+git checkout <VERSION>
+```
+
+### 2. Apply modifications
+
+Make the necessary changes or backport patches from the main branch. For detailed patching guidance, see the [Patching](/how-to/packaging/patching.md) guide.
+
+### 3. Increment the version suffix
+
+The GitHub Actions job that created the `<VERSION>gl0` tag automatically added a `version_suffix=gl0` line to the `prepare_source` script. Simply increment this suffix.
+
+In certain scenarios where you want to backport to an older Garden Linux version, you will also need to update the `.container` file and use the appropriate container image.
+
+:::tip
+You can use the [`bin/find-build-container-for`](https://github.com/gardenlinux/gardenlinux/blob/016c3889e20cb4bd937da4338f88c380cd9a49be/bin/find-build-container-for) script to find the correct container image.
+
+e.g.
+
+```bash
+bin/find-build-container-for 2150.0.0
+ghcr.io/gardenlinux/repo-debian-snapshot@sha256:99f72494ab45d33958a0385054de4742c7022ab07b4c0c2cef6f785f8ebfb378
+```
+
+:::
+
+### Optional: Build Locally
+
+To check if your package builds before pushing it, refer to the [local Build How-To](/how-to/packaging/local-build.md).
+
+### 4. Push the branch
+
+```bash
+git push origin <VERSION>
+```
+
+If the action is set up to run on `push` (as in the basic example), this will trigger the build job. The job will detect that this is a new version and create the necessary tags and GitHub releases.
+
+## Backporting Examples
+
+### Backporting New Upstream Version Not Available (yet) on Salsa
+
+When backporting a version not available (yet) in Debian salsa (e.g., OpenSSL 3.1.7), configure the `prepare_source` script as follows:
+
+```bash
+version_orig=3.1.7
+version="$version_orig-0"
+git_src --branch "openssl-$version_orig" https://github.com/openssl/openssl.git
+apt_src --ignore-orig openssl
+version_suffix=gl0~bp1443
+```
+
+This configuration fetches source files from the upstream repository while using the Debian folder from the apt source package. If there are compatibility issues, patches may need to be added using the `apply_patches` function.
+
+### Backporting Package Already in Nightly Releases
+
+For packages available in Debian testing and tracked in salsa (e.g., `jq` version `1.8.1`):
+
+```bash
+pkg=jq
+version_orig=1.8.1
+version="$version_orig-3"
+# look up in salsa what the correct branch is
+git_src -b "debian/$version" https://salsa.debian.org/debian/jq.git
+
+version_suffix=gl0+bp1877
+```
+
+### Backporting Missing Salsa Sources (Last Resort)
+
+:::warning
+Use this method only as a last resort when source code is not available in Debian salsa or when upstream sources differ significantly. In all other cases, this method is discouraged.
+:::
+
+For packages present in Garden Linux nightly snapshots but not in salsa (e.g., `sqlite3` version `3.46.1`):
+
+```bash
+pkg=sqlite3
+version_orig=3.46.1
+version="${version_orig}-7"
+version_suffix="gl0+bp1877"
+
+# Option 1: Use a known snapshot timestamp
+# snapshot=1754316590
+
+# Option 2: Search through Garden Linux nightly versions
+snapshot_gl_version="1943" # Start searching from this GL nightly version and search forward 30 versions
+snapshot=$(pkg_version_in_gl_version "$pkg" "$version" "$snapshot_gl_version" 30)
+
+# Get sources from snapshot
+snapshot_src "$pkg" "$snapshot_timestamp"
+```
+
+:::info
+Debian snapshots can be useful for determining when Garden Linux snapshots contain a certain package version. For example, visit https://snapshot.debian.org/package/sqlite3/3.46.1-7/ to find the date `2025-07-26`, then use `bin/garden-version --major 2025-07-26` to get `1943` as a candidate version for `snapshot_gl_version`.
+:::
+
+## Related Topics
+
+<RelatedTopics />

--- a/docs/how-to/build-dependencies.md
+++ b/docs/how-to/build-dependencies.md
@@ -69,7 +69,7 @@ The bp-package repository is **not** included in the `package-releases` file of 
 In rescent Garden Linux Release, some `bp-*` packages ended up in the `package-releases` files. Be aware of this.
 :::
 
-## Using Build Dependencies in Workflows
+## Using build dependencies in workflows
 
 Specify the build dependency in the GitHub Actions workflow of the main package using the `build_dep` parameter.
 
@@ -92,7 +92,7 @@ jobs:
 - `build_dep`: Specifies the dependency repository and version in the format `<repo> <tag>`
 - The dependency is automatically fetched and made available during the build
 
-## Complete Example
+## Complete example
 
 For a package that requires a patched version of libtool:
 
@@ -106,7 +106,7 @@ build_dep: gardenlinux/bp-package-libtool 0.0.1-0gl0+bp1
 
 The build system will automatically fetch the dependency and use it during compilation.
 
-## Important Notes
+## Important notes
 
 :::warning
 Build-time dependencies between packages are not updated automatically and need to be adjusted manually when needed.
@@ -120,6 +120,6 @@ bp-package repositories should be kept minimal and focused only on providing the
 For widely-used dependencies that will be needed by multiple packages, consider adding them to the base Garden Linux environment instead of using bp-package.
 :::
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/build-dependencies.md
+++ b/docs/how-to/build-dependencies.md
@@ -1,0 +1,125 @@
+---
+title: Build Dependencies
+description: Learn how to create and manage one-shot build dependencies
+order: 6
+related_topics:
+  - /explanation/release-hierarchy.md
+  - /explanation/packaging.md
+  - /explanation/package-sources.md
+  - /explanation/repo-infrastructure.md
+  - /explanation/os-releases.md
+  - /explanation/semver.md
+  - /how-to/releases/package-releases.md
+  - /how-to/packaging/local-build.md
+  - /how-to/packaging/github-actions.md
+  - /how-to/packaging/creating-packages.md
+  - /how-to/packaging/backporting.md
+  - /how-to/packaging/patching.md
+  - /how-to/packaging/build-dependencies.md
+  - /how-to/packaging/null-releases.md
+  - /reference/packaging-rules.md
+migration_status: "done"
+migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
+migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
+migration_approved: false
+github_org: gardenlinux
+github_repo: package-build
+github_source_path: docs/how-to/build-dependencies.md
+github_target_path: docs/how-to/packaging/build-dependencies.md
+---
+
+# Build Dependencies
+
+This guide covers how to create and manage one-shot build dependencies for Garden Linux packages using bp-package repositories.
+
+## What are Build Dependencies?
+
+Some packages require specific versions of library or tool dependencies that are not available in the base Garden Linux environment or in Debian. These are called **build-time dependencies** - they are only needed during the compilation process, not at runtime.
+
+In Garden Linux, we use **bp-package repositories** ("build-package") to handle these special build dependencies. These repositories are one-shot solutions that provide exactly what's needed for a specific package build.
+
+## When to Use bp-package Repositories
+
+Use a bp-package repository when:
+
+- A package (ABC) requires a build dependency (XYZ) in a specific version
+- The required version of XYZ is not available in the base Garden Linux environment
+- The dependency is only needed for building, not for runtime
+- You need to apply specific patches to the dependency before building
+- The dependency is temporary or experimental
+
+**Examples**:
+
+- Building a package against a newer version of a library
+- Applying security patches to a build tool
+- Using a forked version of a dependency
+- Experimental features requiring custom dependencies
+
+## Creating a bp-package Repository
+
+To create a bp-package repository:
+
+1. Create a new repository with the naming convention `bp-package-<name> <version>`
+2. Follow the same packaging rules as regular packages
+3. Build and release the package to GitHub
+
+The bp-package repository is **not** included in the `package-releases` file of gardenlinux/repo, but it is included in the build of the dependent package.
+
+:::danger
+In rescent Garden Linux Release, some `bp-*` packages ended up in the `package-releases` files. Please be aware of this.
+:::
+
+## Using Build Dependencies in Workflows
+
+Specify the build dependency in the GitHub Actions workflow of the main package using the `build_dep` parameter.
+
+```yaml
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  build:
+    uses: gardenlinux/package-build/.github/workflows/build.yml@main
+    with:
+      release: ${{ github.ref == 'refs/heads/main' }}
+      build_dep: gardenlinux/package-XYZ 0.0.1-0gl0+bpwhatever
+```
+
+**Parameters**:
+
+- `build_dep`: Specifies the dependency repository and version in the format `<repo> <tag>`
+- The dependency is automatically fetched and made available during the build
+
+## Complete Example
+
+For a package that requires a patched version of libtool:
+
+1. Create `bp-package-libtool` repository with the patched version
+2. Release version `0.0.1-0gl0+bp1`
+3. In the main package workflow, add:
+
+```yaml
+build_dep: gardenlinux/bp-package-libtool 0.0.1-0gl0+bp1
+```
+
+The build system will automatically fetch the dependency and use it during compilation.
+
+## Important Notes
+
+:::warning
+Build-time dependencies between packages are not updated automatically and need to be adjusted manually when needed.
+:::
+
+:::info
+bp-package repositories should be kept minimal and focused only on providing the necessary build dependency. They are not intended for general use or long-term maintenance.
+:::
+
+:::tip
+For widely-used dependencies that will be needed by multiple packages, consider adding them to the base Garden Linux environment instead of using bp-package.
+:::
+
+## Related Topics
+
+<RelatedTopics />

--- a/docs/how-to/build-dependencies.md
+++ b/docs/how-to/build-dependencies.md
@@ -66,7 +66,7 @@ To create a bp-package repository:
 The bp-package repository is **not** included in the `package-releases` file of gardenlinux/repo, but it is included in the build of the dependent package.
 
 :::danger
-In rescent Garden Linux Release, some `bp-*` packages ended up in the `package-releases` files. Please be aware of this.
+In rescent Garden Linux Release, some `bp-*` packages ended up in the `package-releases` files. Be aware of this.
 :::
 
 ## Using Build Dependencies in Workflows

--- a/docs/how-to/creating-packages.md
+++ b/docs/how-to/creating-packages.md
@@ -1,0 +1,189 @@
+---
+title: Creating Packages
+description: Learn how to create Garden Linux Packages
+order: 1
+related_topics:
+  - /explanation/release-hierarchy.md
+  - /explanation/packaging.md
+  - /explanation/package-sources.md
+  - /explanation/repo-infrastructure.md
+  - /explanation/os-releases.md
+  - /explanation/semver.md
+  - /how-to/releases/package-releases.md
+  - /how-to/packaging/local-build.md
+  - /how-to/packaging/github-actions.md
+  - /how-to/packaging/creating-packages.md
+  - /how-to/packaging/backporting.md
+  - /how-to/packaging/patching.md
+  - /how-to/packaging/build-dependencies.md
+  - /how-to/packaging/null-releases.md
+  - /reference/packaging-rules.md
+migration_status: "done"
+migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
+migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
+migration_approved: false
+github_org: gardenlinux
+github_repo: package-build
+github_source_path: docs/how-to/creating-packages.md
+github_target_path: docs/how-to/packaging/creating-packages.md
+---
+
+# Creating Packages
+
+This guide covers the complete workflow for creating Garden Linux packages, from initial setup to handover to the repository infrastructure.
+
+## Overview
+
+The package creation process follows these stages:
+
+1. Prepare the package source
+2. Make source package
+3. Make binary package
+4. Test binary package
+5. Handover to repo build
+
+This guide walks through each stage in detail, integrating the rules and best practices for Garden Linux packages.
+
+## Step 1: Prepare the Package Source
+
+The package source consists of three components that must be assembled:
+
+1. **Upstream source code**
+2. **The debian/ folder**
+3. **Garden Linux patches**
+
+The `prepare_source` script is responsible for assembling these components and is executed as a step in the [gardenlinux/package-build:bin/source](https://github.com/gardenlinux/package-build/blob/main/bin/source) workflow.
+
+### Get the debian/ folder
+
+The method for obtaining the debian/ folder depends on whether the package exists in Debian:
+
+| Scenario                            | Method                                        |
+| ----------------------------------- | --------------------------------------------- |
+| Package in Debian testing           | Get from Garden Linux snapshot apt repository |
+| Package not in testing but in salsa | Get from salsa.debian.org                     |
+| Package not in Debian at all        | Create and maintain in package repository     |
+
+**For packages in Debian testing**:
+
+Use the `apt_src` helper function (according to [Rule 4](/reference/packaging-rules.html#rule-4-get-debian-folder-from-garden-linux-snapshot-apt-repository)):
+
+```bash
+apt_src --ignore_orig <source_package_name>
+```
+
+**For packages not in Debian**:
+
+Manually create the `debian/` folder with all required files and check it into the `package-` repository.
+
+:::tip
+Use existing similar packages as templates and follow the Debian maintainer documentation.
+:::
+
+### Get the upstream source
+
+Get the source code from the upstream git repository, not from Debian source packages. This enables automated version tracking using uscan.
+
+Use the `git_src` helper function:
+
+```bash
+git_src --branch <BRANCH_NAME> <GIT_REPO_URL>
+```
+
+For example, to get OpenSSL 3.1.7:
+
+```bash
+version_orig=3.1.7
+git_src --branch "openssl-$version_orig" https://github.com/openssl/openssl.git
+```
+
+:::info
+For packages already in Debian, get the source from salsa.debian.org using the appropriate Debian branch.
+:::
+
+### Apply Garden Linux patches
+
+Apply both debian/ folder patches and upstream source patches in the `prepare_source` script.
+
+**For debian/ folder patches**:
+
+Place patches in a `fixes_debian` directory and use:
+
+```bash
+apply_patches fixes_debian
+```
+
+**For upstream source patches**:
+
+Place patches in an `upstream_patches` directory and use:
+
+```bash
+import_upstream_patches# upstream_patches
+```
+
+For detailed patching procedures, see the [Patching](/how-to/packaging/patching.md) guide.
+
+## Step 2: Make the Source Package
+
+A source package contains all necessary files to build the binaries and serves as input for the binary build step.
+
+The gardenlinux/package-build repository provides reusable actions to perform this step automatically. See the [build.yml workflow](https://github.com/gardenlinux/package-build/blob/621c4c8f530a93884f7b9a4dfc348a50a2d19aa5/.github/workflows/build.yml#L29) for reference.
+
+The source package generation process:
+
+1. Executes the `prepare_source` script to assemble all components
+2. Creates a .tar.gz archive of the source
+3. Generates the .dsc file with package metadata
+4. Computes checksums for all files
+
+## Step 3: Make the Binary Package
+
+Input for this stage is the debian source package created in the previous step.
+
+The gardenlinux/package-build repository provides reusable actions to automatically perform the binary build. This process:
+
+1. Extracts the source package
+2. Applies all patches (from debian/patches and imported upstream patches)
+3. Compiles the source code
+4. Packages the compiled binaries into .deb files
+
+A `prepare_binary` script can be added to the package repository to perform additional preparations before the build, such as:
+
+- Reconfiguring debian build profiles
+- Installing additional build dependencies
+- Adding logging flags for debugging
+
+## Step 4: Test the Binary Package
+
+Currently, tests are disabled by default using the `nocheck` debian build profile. However, manual testing is recommended for critical packages.
+
+To enable testing, remove the `nocheck` profile in `DEB_BUILD_OPTIONS` and ensure appropriate test dependencies are available.
+
+:::tip
+For packages where security is critical, consider adding automated tests in a separate workflow.
+:::
+
+## Step 5: Handover to Repo Build
+
+The gardenlinux/repo repository is responsible for collecting all required packages and creating the apt repositories.
+
+### Daily releases
+
+A daily scheduled action in gardenlinux/repo collects the latest releases and creates a new apt repository:
+
+1. Gets the list of `gardenlinux/package-*` repositories
+2. Downloads each package/version from the GitHub Releases of the respective package-\* repository
+
+### Patch releases
+
+Packages for patch releases are uploaded to GitHub Releases but must be manually included in the gardenlinux/repo configuration:
+
+1. Create the package release as usual
+2. Update the `package-releases` and `package-imports` files in the `repo` repository
+3. Create a new tag for the APT repository release
+
+For complete details on apt repository creation, see the [Creating APT Repository Releases](/how-to/releases/apt-repos.md) guide.
+
+## Related Topics
+
+<RelatedTopics />

--- a/docs/how-to/creating-packages.md
+++ b/docs/how-to/creating-packages.md
@@ -125,7 +125,7 @@ For detailed patching procedures, see the [Patching](/how-to/packaging/patching.
 
 ## Step 2: Make the Source Package
 
-A source package contains all necessary files to build the binaries and serves as input for the binary build step.
+A source package contains all necessary files to build the binaries and is the input for the binary build step.
 
 The gardenlinux/package-build repository provides reusable actions to perform this step automatically. See the [build.yml workflow](https://github.com/gardenlinux/package-build/blob/621c4c8f530a93884f7b9a4dfc348a50a2d19aa5/.github/workflows/build.yml#L29) for reference.
 
@@ -184,6 +184,6 @@ Packages for patch releases are uploaded to GitHub Releases but must be manually
 
 For complete details on apt repository creation, see the [Creating APT Repository Releases](/how-to/releases/apt-repos.md) guide.
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/github-actions.md
+++ b/docs/how-to/github-actions.md
@@ -89,6 +89,6 @@ jobs:
       release: ${{ github.ref == 'refs/heads/main' }}
 ```
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/github-actions.md
+++ b/docs/how-to/github-actions.md
@@ -1,0 +1,94 @@
+---
+title: Github Actions Package Building
+description: Learn how Garden Linux Packages are built in Github Actions
+order: 4
+related_topics:
+  - /explanation/release-hierarchy.md
+  - /explanation/packaging.md
+  - /explanation/package-sources.md
+  - /explanation/repo-infrastructure.md
+  - /explanation/os-releases.md
+  - /explanation/semver.md
+  - /how-to/releases/package-releases.md
+  - /how-to/packaging/local-build.md
+  - /how-to/packaging/github-actions.md
+  - /how-to/packaging/creating-packages.md
+  - /how-to/packaging/backporting.md
+  - /how-to/packaging/patching.md
+  - /how-to/packaging/build-dependencies.md
+  - /how-to/packaging/null-releases.md
+  - /reference/packaging-rules.md
+migration_status: "done"
+migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
+migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
+migration_approved: false
+github_org: gardenlinux
+github_repo: package-build
+github_source_path: docs/how-to/github-actions.md
+github_target_path: docs/how-to/packaging/github-actions.md
+---
+
+# GitHub Actions Package Building
+
+This guide covers how to build Garden Linux packages using GitHub Actions workflows.
+
+## Workflow Configuration
+
+To build packages using GitHub Actions, define a job that uses the package-build workflow:
+
+```yaml
+jobs:
+  build:
+    uses: gardenlinux/package-build/.github/workflows/build.yml@main
+```
+
+## Job Inputs
+
+The GitHub Actions workflow accepts several inputs to customize the build process.
+
+### `release` (boolean)
+
+Flag to indicate if this is a release build. When set to `true`:
+
+- Automatically appends `gl0` as the version suffix
+- Creates a GitHub release from the resulting source and binary packages
+
+Example usage:
+
+```yaml
+with:
+  release: ${{ github.ref == 'refs/heads/main' }}
+```
+
+### `build_dep` (string)
+
+A list of other GitHub repositories to pull custom build-time dependencies from, in the format `<repo> <tag>`.
+
+:::warning
+Build-time dependencies between packages are not updated automatically and need to be adjusted manually when needed.
+:::
+
+### `runs-on`, `runs-on-amd64`, `runs-on-arm64` (string)
+
+Specify the GitHub Actions runner on which to execute the job.
+
+## Complete Example
+
+A full GitHub workflow file that builds a package and periodically checks for new versions:
+
+```yaml
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  build:
+    uses: gardenlinux/package-build/.github/workflows/build.yml@main
+    with:
+      release: ${{ github.ref == 'refs/heads/main' }}
+```
+
+## Related Topics
+
+<RelatedTopics />

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -31,13 +31,13 @@ github_target_path: docs/how-to/packaging/index.md
 
 The Garden Linux packaging system enables the creation of customized operating system images through a modular approach. This guide provides an overview of the complete package release lifecycle and links to detailed how-to guides for each stage.
 
-## Release Hierarchy
+## Release hierarchy
 
 Garden Linux uses a [three-tier release hierarchy](/explanation/release-hierarchy.md) to deliver a complete operating system.
 
 This document is about the first tier, the [Packaging Ecosystem](/how-to/releases/package-releases).
 
-## Package Release Lifecycle
+## Package release lifecycle
 
 Creating and releasing packages in Garden Linux follows a structured process:
 
@@ -50,13 +50,13 @@ Creating and releasing packages in Garden Linux follows a structured process:
 5. **[Managing Dependencies](/how-to/packaging/build-dependencies.md)**: Handle special build-time dependencies with bp-package repositories
 6. **[Excluding Packages](/how-to/packaging/null-releases.md)**: Use NULL releases to temporarily exclude problematic packages from builds
 
-## Core Concepts
+## Core concepts
 
 - **[Packaging Rules](/reference/packaging-rules.md)**: Authoritative reference for all naming conventions and procedural rules
 - **[Package Sources](/explanation/package-sources.md)**: Understand the different types of package sources in Garden Linux
 - **[Repository Infrastructure](https://github.com/gardenlinux/repo/blob/main/docs/explanation/infrastructure.md)**: Learn how packages are assembled into apt repositories
 
-## Getting Started
+## Getting started
 
 1. Review the [Packaging Rules](/reference/packaging-rules.md) for naming conventions and repository structure
 2. Choose a package to work on (either a new package or modifying an existing one)

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,6 +1,6 @@
 ---
 title: Packaging
-description: Comprehensive guide to the Garden Linux packaging system and release lifecycle
+description: Complete guide to the Garden Linux packaging system and release lifecycle
 related_topics:
   - /explanation/release-hierarchy.md
   - /explanation/packaging.md

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,0 +1,68 @@
+---
+title: Packaging
+description: Comprehensive guide to the Garden Linux packaging system and release lifecycle
+related_topics:
+  - /explanation/release-hierarchy.md
+  - /explanation/packaging.md
+  - /explanation/package-sources.md
+  - /explanation/repo-infrastructure.md
+  - /explanation/os-releases.md
+  - /explanation/semver.md
+  - /how-to/releases/package-releases.md
+  - /how-to/packaging/local-build.md
+  - /how-to/packaging/github-actions.md
+  - /how-to/packaging/creating-packages.md
+  - /how-to/packaging/backporting.md
+  - /how-to/packaging/patching.md
+  - /how-to/packaging/build-dependencies.md
+  - /how-to/packaging/null-releases.md
+  - /reference/packaging-rules.md
+migration_status: "done"
+migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
+migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
+migration_approved: false
+github_org: gardenlinux
+github_repo: package-build
+github_source_path: docs/how-to/index.md
+github_target_path: docs/how-to/packaging/index.md
+---
+
+# Packaging
+
+The Garden Linux packaging system enables the creation of customized operating system images through a modular approach. This guide provides an overview of the complete package release lifecycle and links to detailed how-to guides for each stage.
+
+## Release Hierarchy
+
+Garden Linux uses a [three-tier release hierarchy](/explanation/release-hierarchy.md) to deliver a complete operating system.
+
+This document is about the first tier, the [Packaging Ecosystem](/how-to/releases/package-releases).
+
+## Package Release Lifecycle
+
+Creating and releasing packages in Garden Linux follows a structured process:
+
+1. **[Creating Packages](/how-to/packaging/creating-packages.md)**: Start with this guide to learn how to create a new package or modify an existing one
+2. **[Applying Patches](/how-to/packaging/patching.md)**: Learn how to create and manage patches for both debian/ folder changes and upstream source modifications
+3. **Building Packages**: Choose your preferred method:
+   - **[Local Builds](/how-to/packaging/local-build.md)**: Build packages on your development machine
+   - **[GitHub Actions](/how-to/packaging/github-actions.md)**: Automate builds with CI/CD
+4. **[Backporting](/how-to/packaging/backporting.md)**: Create patch releases for specific Garden Linux versions
+5. **[Managing Dependencies](/how-to/packaging/build-dependencies.md)**: Handle special build-time dependencies with bp-package repositories
+6. **[Excluding Packages](/how-to/packaging/null-releases.md)**: Use NULL releases to temporarily exclude problematic packages from builds
+
+## Core Concepts
+
+- **[Packaging Rules](/reference/packaging-rules.md)**: Authoritative reference for all naming conventions and procedural rules
+- **[Package Sources](/explanation/package-sources.md)**: Understand the different types of package sources in Garden Linux
+- **[Repository Infrastructure](https://github.com/gardenlinux/repo/blob/main/docs/explanation/infrastructure.md)**: Learn how packages are assembled into apt repositories
+
+## Getting Started
+
+1. Review the [Packaging Rules](/reference/packaging-rules.md) for naming conventions and repository structure
+2. Choose a package to work on (either a new package or modifying an existing one)
+3. Follow the [Creating Packages](/how-to/packaging/creating-packages.md) guide to set up your package
+4. Use the appropriate build method (local or GitHub Actions)
+5. Test your package thoroughly before releasing
+6. Create a GitHub release to make it available for inclusion in Garden Linux
+
+For maintainers creating packages for the first time, we recommend reading through all the guides in order to understand the complete workflow.

--- a/docs/how-to/local-build.md
+++ b/docs/how-to/local-build.md
@@ -28,7 +28,7 @@ github_source_path: docs/how-to/local-build.md
 github_target_path: docs/how-to/packaging/local-build.md
 ---
 
-# Local Package Building
+# Local package building
 
 This guide covers how to build Garden Linux packages locally using the `package-build` tools.
 
@@ -38,7 +38,7 @@ This guide covers how to build Garden Linux packages locally using the `package-
 - Sufficient disk space for builds
 - Access to the Garden Linux package repositories
 
-## Build Process
+## Build process
 
 ### 1. Clone the package-build repository
 
@@ -66,11 +66,11 @@ Execute the build script from the package-build repository, passing your package
 If your package build depends on other custom build packages, you can provide the `--build-dependencies` flag with a directory containing the `.deb` files of build-time dependencies.
 :::
 
-## Build Artifacts
+## Build artifacts
 
 The build artifacts (`.deb` files and others) are placed in a `.build` directory within your package repository. For example: `./package-iproute2/.build/`.
 
-## Build Options
+## Build options
 
 The `build` script supports several options to customize the build process:
 
@@ -81,6 +81,6 @@ The `build` script supports several options to customize the build process:
 - `--build-dependencies`: Path to a directory containing `.deb` files to be used as build-time dependencies
 - `--edit`: Spawn a gardenlinux/repo-debian-snapshort container with `package-XYZ/output` mounted, quilt installed and configured
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/local-build.md
+++ b/docs/how-to/local-build.md
@@ -1,0 +1,86 @@
+---
+title: Local Package Building
+description: Learn how Garden Linux Packages are built locally
+order: 3
+related_topics:
+  - /explanation/release-hierarchy.md
+  - /explanation/packaging.md
+  - /explanation/package-sources.md
+  - /explanation/repo-infrastructure.md
+  - /explanation/os-releases.md
+  - /explanation/semver.md
+  - /how-to/releases/package-releases.md
+  - /how-to/packaging/local-build.md
+  - /how-to/packaging/github-actions.md
+  - /how-to/packaging/creating-packages.md
+  - /how-to/packaging/backporting.md
+  - /how-to/packaging/patching.md
+  - /how-to/packaging/build-dependencies.md
+  - /how-to/packaging/null-releases.md
+  - /reference/packaging-rules.md
+migration_status: "done"
+migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
+migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
+migration_approved: false
+github_org: gardenlinux
+github_repo: package-build
+github_source_path: docs/how-to/local-build.md
+github_target_path: docs/how-to/packaging/local-build.md
+---
+
+# Local Package Building
+
+This guide covers how to build Garden Linux packages locally using the `package-build` tools.
+
+## Prerequisites
+
+- Git installed on your system
+- Sufficient disk space for builds
+- Access to the Garden Linux package repositories
+
+## Build Process
+
+### 1. Clone the package-build repository
+
+```bash
+git clone https://github.com/gardenlinux/package-build.git
+```
+
+### 2. Clone the target package repository
+
+Choose the package you want to build and clone its repository. For example, to build iproute2:
+
+```bash
+git clone https://github.com/gardenlinux/package-iproute2.git
+```
+
+### 3. Run the build script
+
+Execute the build script from the package-build repository, passing your package directory as an argument:
+
+```bash
+./package-build/build package-iproute2
+```
+
+:::info
+If your package build depends on other custom build packages, you can provide the `--build-dependencies` flag with a directory containing the `.deb` files of build-time dependencies.
+:::
+
+## Build Artifacts
+
+The build artifacts (`.deb` files and others) are placed in a `.build` directory within your package repository. For example: `./package-iproute2/.build/`.
+
+## Build Options
+
+The `build` script supports several options to customize the build process:
+
+- `--arch amd64`: Specify the architecture to build (default: `amd64`, choices: `amd64`, `arm64`)
+- `--source-only`: Build only the source archive
+- `--binary-only`: Build only the binary archives
+- `--leave-artifacts`: Create the sources folder and keep them in a `package-XYZ/output/run_<date_time>` folder of the local `package-XYZ` directory
+- `--build-dependencies`: Path to a directory containing `.deb` files to be used as build-time dependencies
+- `--edit`: Spawn a gardenlinux/repo-debian-snapshort container with `package-XYZ/output` mounted, quilt installed and configured
+
+## Related Topics
+
+<RelatedTopics />

--- a/docs/how-to/null-releases.md
+++ b/docs/how-to/null-releases.md
@@ -1,6 +1,6 @@
 ---
 title: NULL Releases
-description: Learn how to use NULL releases to exclude Packages frin Garden Linux builds
+description: Learn how to use NULL releases to exclude Packages from Garden Linux builds
 order: 7
 related_topics:
   - /explanation/release-hierarchy.md
@@ -92,7 +92,7 @@ to re-enable a package that was previously disabled with a NULL release, you hav
 
 ## Important Considerations
 
-:::error
+:::danger
 If you want to permanently remove/archive a package from Garden Linux, please follow the [official guide](https://github.com/gardenlinux/repo?tab=readme-ov-file#remove-garden-linux-packages-from-the-repo) in the gardenlinux/repo repository.
 :::
 

--- a/docs/how-to/null-releases.md
+++ b/docs/how-to/null-releases.md
@@ -1,0 +1,109 @@
+---
+title: NULL Releases
+description: Learn how to use NULL releases to exclude Packages frin Garden Linux builds
+order: 7
+related_topics:
+  - /explanation/release-hierarchy.md
+  - /explanation/packaging.md
+  - /explanation/package-sources.md
+  - /explanation/repo-infrastructure.md
+  - /explanation/os-releases.md
+  - /explanation/semver.md
+  - /how-to/releases/package-releases.md
+  - /how-to/packaging/local-build.md
+  - /how-to/packaging/github-actions.md
+  - /how-to/packaging/creating-packages.md
+  - /how-to/packaging/backporting.md
+  - /how-to/packaging/patching.md
+  - /how-to/packaging/build-dependencies.md
+  - /how-to/packaging/null-releases.md
+  - /reference/packaging-rules.md
+migration_status: "done"
+migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
+migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
+migration_approved: false
+github_org: gardenlinux
+github_repo: package-build
+github_source_path: docs/how-to/null-releases.md
+github_target_path: docs/how-to/packaging/null-releases.md
+---
+
+# NULL Releases
+
+This guide explains how to use NULL releases to exclude packages from Garden Linux builds, following the process described in [MAINTAINER.md](https://github.com/gardenlinux/package-build/blob/main/MAINTAINER.md#disable-a-package-xyz-repository-null-release-handling).
+
+## What is a NULL Release?
+
+A NULL release is a special GitHub release that tells the Garden Linux repository infrastructure to ignore a package for inclusion in apt repositories. When the `fetch_releases` script encounters a NULL release marked as the latest, it skips that package during the repository build process.
+
+NULL releases are used to:
+
+- Temporarily disable a package that is causing build failures
+- Remove a package from the distribution
+- Exclude packages with licensing or security issues
+- Mark deprecated packages
+
+## How NULL Releases Work
+
+The null release mechanism operates through several components in the Garden Linux infrastructure:
+
+1. **`fetch_releases` script**: Part of the gardenlinux/repo GitHub Actions, this script iterates through all gardenlinux/package-\* repositories and gets the latest release tag
+2. **`download_pkgs` script**: Downloads the latest release files from all package-\* GitHub Releases
+3. **Null file detection**: If the latest release of a package-\* repository contains a `null` file, it is ignored and not included in the apt repository
+
+This creates a simple but effective way to exclude packages without modifying configuration files or deleting repositories.
+
+## Creating a NULL Release
+
+To create a NULL release that excludes a package from Garden Linux builds:
+
+```bash
+git checkout --detach
+git commit --allow-empty -m "ignore package for repo import"
+git tag null
+git push origin null
+echo "" > null
+gh release create null ./null --title "Null release" --notes "null"
+```
+
+**Step-by-step explanation**:
+
+1. `git checkout --detach`: Create a detached HEAD to avoid affecting any branches
+2. `git commit --allow-empty -m "ignore package for repo import"`: Create an empty commit with descriptive message
+3. `git tag null`: Create a lightweight tag named "null"
+4. `git push origin null`: Push the null tag to the remote repository
+5. `echo "" > null`: Create an empty file named "null"
+6. `gh release create null ./null --title "Null release" --notes "null"`: Create a GitHub release with the null file attached
+
+## Re-enabling a Package
+
+to re-enable a package that was previously disabled with a NULL release, you have two options:
+
+**Option 1: Create a new regular release**
+
+- Create a new version of the package
+- Build and release it normally
+- The new release will become the latest and override the NULL release
+
+**Option 2: Set the appropriate version as latest**
+
+- If the package already has a proper release after the NULL release, you can manually set it as the latest release on GitHub
+- This effectively bypasses the NULL release
+
+## Important Considerations
+
+:::error
+If you want to permanently remove/archive a package from Garden Linux, please follow the [official guide](https://github.com/gardenlinux/repo?tab=readme-ov-file#remove-garden-linux-packages-from-the-repo) in the gardenlinux/repo repository.
+:::
+
+:::warning
+NULL releases should only be used for packages maintained by the Garden Linux team. For third-party packages or external dependencies, other exclusion mechanisms may be more appropriate.
+:::
+
+:::info
+NULL releases are particularly useful for temporarily disabling packages that are failing to build, allowing the rest of the release process to continue while the issue is investigated.
+:::
+
+## Related Topics
+
+<RelatedTopics />

--- a/docs/how-to/null-releases.md
+++ b/docs/how-to/null-releases.md
@@ -43,7 +43,7 @@ NULL releases are used to:
 - Exclude packages with licensing or security issues
 - Mark deprecated packages
 
-## How NULL Releases Work
+## How NULL releases work
 
 The null release mechanism operates through several components in the Garden Linux infrastructure:
 

--- a/docs/how-to/null-releases.md
+++ b/docs/how-to/null-releases.md
@@ -93,7 +93,7 @@ to re-enable a package that was previously disabled with a NULL release, you hav
 ## Important Considerations
 
 :::danger
-If you want to permanently remove/archive a package from Garden Linux, please follow the [official guide](https://github.com/gardenlinux/repo?tab=readme-ov-file#remove-garden-linux-packages-from-the-repo) in the gardenlinux/repo repository.
+If you want to permanently remove/archive a package from Garden Linux, follow the [official guide](https://github.com/gardenlinux/repo?tab=readme-ov-file#remove-garden-linux-packages-from-the-repo) in the gardenlinux/repo repository.
 :::
 
 :::warning

--- a/docs/how-to/package-releases.md
+++ b/docs/how-to/package-releases.md
@@ -28,17 +28,17 @@ github_source_path: docs/how-to/package-releases.md
 github_target_path: docs/how-to/releases/package-releases.md
 ---
 
-# Creating Package Releases
+# Creating package releases
 
 This guide explains how to create Garden Linux Package releases.
 
-## Release Hierarchy
+## Release hierarchy
 
 Garden Linux uses a [three-tier release hierarchy](/explanation/release-hierarchy.md) to deliver a complete operating system.
 
 This document is about the first tier, the [Packaging](/explanation/packaging).
 
-## Understanding Packaging
+## Understanding packaging
 
 Read the [Packaging Explanation](/explanation/packaging.md) to get familiar with the concepts of Packaging.
 
@@ -51,7 +51,7 @@ Before creating an OS release, ensure you have:
 
 ## Phase 0: Preparation
 
-### Step 1: Decide What to Include
+### Step 1: Decide what to include
 
 In tier one, individual [packages](/explanation/packaging.md) will need updates based on e.g. recent CVEs. Check for potential upgrades in important packages, too:
 
@@ -77,9 +77,9 @@ The complexity of updating a package varies:
 
 For complex updates, thoroughly test the new package version before including it in a release.
 
-## Phase 1: Creating the Release
+## Phase 1: Creating the release
 
-### Step 1: Create APT Repository Release
+### Step 1: Create APT repository release
 
 In tier two, the [APT repository](/explanation/repo-infrastructure.md) must be created before building OS images.
 
@@ -196,7 +196,7 @@ gh workflow run nightly.yml \
 - Verify all build jobs complete successfully
 - Check that artifacts are published
 
-### Step 3: Create GitHub Release
+### Step 3: Create GitHub release
 
 After the build completes, create the official GitHub release page:
 
@@ -284,7 +284,7 @@ git push -u origin rel-2150
 
 This branch is used for creating future minor releases of the APT repository.
 
-### Step 5: Generate CPE File
+### Step 5: Generate CPE file
 
 Generate the Common Platform Enumeration (CPE) file for the new release:
 
@@ -307,27 +307,27 @@ Or via GitHub UI:
 3. Select `main` branch
 4. Set version to `MAJOR.MINOR.0`
 
-### Step 6: Update Garden Linux Documentation
+### Step 6: Update Garden Linux documentation
 
 :::info
 TODO: add steps on how to update the documentation
 :::
 
-## Phase 2: Post-Release Work
+## Phase 2: Post-release work
 
-### Verify Release Completeness
+### Verify release completeness
 
 - Verify the GitHub release page is complete and accurate
 - Check that all expected artifacts are attached to the release
 - Confirm the CPE file was generated and uploaded
 - Test installation using the new release
 
-### Notify Stakeholders
+### Notify stakeholders
 
 - Notify relevant teams about the new release
 - Gardener OS Extension Team
 - Update any documentation referencing supported versions
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/package-releases.md
+++ b/docs/how-to/package-releases.md
@@ -1,0 +1,333 @@
+---
+title: Creating Package Releases
+description: Comprehensive guide to creating Garden Linux Package releases
+order: 1
+related_topics:
+  - /explanation/release-hierarchy.md
+  - /explanation/packaging.md
+  - /explanation/package-sources.md
+  - /explanation/repo-infrastructure.md
+  - /explanation/os-releases.md
+  - /explanation/semver.md
+  - /how-to/releases/package-releases.md
+  - /how-to/packaging/local-build.md
+  - /how-to/packaging/github-actions.md
+  - /how-to/packaging/creating-packages.md
+  - /how-to/packaging/backporting.md
+  - /how-to/packaging/patching.md
+  - /how-to/packaging/build-dependencies.md
+  - /how-to/packaging/null-releases.md
+  - /reference/packaging-rules.md
+migration_status: "done"
+migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
+migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
+migration_approved: false
+github_org: gardenlinux
+github_repo: gardenlinux
+github_source_path: docs/how-to/package-releases.md
+github_target_path: docs/how-to/releases/package-releases.md
+---
+
+# Creating Package Releases
+
+This guide explains how to create Garden Linux Package releases.
+
+## Release Hierarchy
+
+Garden Linux uses a [three-tier release hierarchy](/explanation/release-hierarchy.md) to deliver a complete operating system.
+
+This document is about the first tier, the [Packaging](/explanation/packaging).
+
+## Understanding Packaging
+
+Please read the [Packaging Explanation](/explanation/packaging.md) to get familiar with the concepts of Packaging.
+
+## Prerequisites
+
+Before creating an OS release, ensure you have:
+
+- Write access to the `gardenlinux/package-*` repositories
+- `git` and `gh` CLI tool installed and configured
+
+## Phase 0: Preparation
+
+### Step 1: Decide What to Include
+
+In tier one, individual [packages](/explanation/packaging.md) will need updates based on e.g. recent CVEs. Check for potential upgrades in important packages, too:
+
+- golang
+- containerd
+- runc
+- curl
+- openssl
+- systemd
+- glibc
+- linux kernel
+
+**For each package requiring an update**, we need to follow the [Package Backporting Guide](/how-to/packaging/backporting.md) later.
+
+1. Navigate to the respective `github.com/gardenlinux/package-{name}` repository
+2. Create a new package release if needed (see [package-build documentation](/explanation/packaging.md) for details)
+3. Note the new version tag for use in the APT repository release
+
+The complexity of updating a package varies:
+
+- **Simple**: Packages that rebuild Debian packages with minimal adaptions
+- **Complex**: Packages with extensive adaptions that may not apply to newer versions, or packages built from upstream sources
+
+For complex updates, thoroughly test the new package version before including it in a release.
+
+## Phase 1: Creating the Release
+
+### Step 1: Create APT Repository Release
+
+In tier two, the [APT repository](/explanation/repo-infrastructure.md) must be created before building OS images.
+
+**For Major Releases:**
+
+Major releases automatically create APT repositories via the nightly `update.yml` workflow in the `repo` repository. The workflow:
+
+- Collects latest package versions from all `package-*` repositories
+- Creates a new Debian snapshot
+- Generates `package-releases` and `.container` files
+- Publishes the APT repository to S3
+
+No manual action is required for major release APT repositories.
+
+**For Minor Releases:**
+
+Follow the comprehensive guide: [Creating APT Repository Releases](/how-to/releases/apt-repos.md)
+
+Quick summary:
+
+1. Checkout the base APT repository release tag in the `repo` repository
+2. Modify `package-releases` and `package-imports` files
+3. Commit and create a new tag (e.g., `2150.1.0`)
+4. Push the tag to trigger the build
+
+**Verify APT Repository:**
+
+- Wait for the `repo` workflow to complete successfully
+- Verify the APT repository is published to S3
+
+### Step 2: Build Garden Linux OS
+
+Once the APT repository is ready, we can build the OS images in tier three:
+
+**Checkout or Create Release Branch:**
+
+```bash
+# For major releases, create a new release branch from main
+git checkout main
+git pull
+git checkout -b rel-MAJOR
+git push origin rel-MAJOR
+
+# For minor releases, checkout the existing release branch
+git checkout rel-MAJOR
+git pull
+```
+
+**Update VERSION File:**
+
+```bash
+# Edit the VERSION file to contain the new version
+echo "MAJOR.MINOR.0" > VERSION
+
+# Example for minor release:
+echo "2150.1.0" > VERSION
+
+# Commit the change
+git add VERSION
+git commit -m "Bump version to MAJOR.MINOR.0"
+git push origin rel-MAJOR
+```
+
+**Trigger Build Workflow:**
+
+The build process varies depending on the Garden Linux version:
+
+**For releases 2016.0.0 and later (using [SemVer](/reference/glossary.html#semver)):**
+
+Use the [manual release workflow](https://github.com/gardenlinux/gardenlinux/actions/workflows/manual_release.yml):
+
+```bash
+# Using gh CLI:
+gh workflow run "Build and publish a release" \
+--ref rel-MAJOR \
+-f target=release \
+-f version=MAJOR.MINOR.0
+
+# Example:
+gh workflow run "Build and publish a release" \
+--ref rel-2150 \
+-f target=release \
+-f version=2150.1.0
+```
+
+Or via the GitHub UI:
+
+1. Go to [Actions → Build and publish a release](https://github.com/gardenlinux/gardenlinux/actions/workflows/manual_release.yml)
+2. Click "Run workflow"
+3. Select the `rel-MAJOR` branch
+4. Set version to `MAJOR.MINOR.0`
+5. Leave target `release`
+6. Leave other parameters at defaults
+
+**For older releases (1443, 1592 using non-SemVer):**
+
+Use the [nightly workflow](https://github.com/gardenlinux/gardenlinux/actions/workflows/nightly.yml) with version parameter:
+
+```bash
+# Using gh CLI:
+gh workflow run nightly.yml \
+--ref rel-MAJOR \
+-f version=MAJOR.MINOR
+
+# Example for 1443:
+gh workflow run nightly.yml \
+--ref rel-1443 \
+-f version=1443.3
+```
+
+**Monitor the Build:**
+
+- Watch the workflow progress in GitHub Actions
+- Verify all build jobs complete successfully
+- Check that artifacts are published
+
+### Step 3: Create GitHub Release
+
+After the build completes, create the official GitHub release page:
+
+```bash
+# Run from main branch (not the release branch!)
+git checkout main
+
+# Using gh CLI:
+gh workflow run "release page" \
+--ref main \
+-f run_id=<BUILD-RUN-ID>
+-f is_latest=true # if this is the latest major.minor.0 version
+
+# Example:
+gh workflow run "release page" \
+--ref main \
+-f run_id=23802291489 \
+-f is_latest=true # if this is the latest major.minor.0 version
+```
+
+:::tip
+Get the "Run ID" from the URL of the "Build and publish a release" workflow run, e.g. https://github.com/gardenlinux/gardenlinux/actions/runs/23802291489
+:::
+
+Or via the GitHub UI:
+
+1. Go to [Actions → release page](https://github.com/gardenlinux/gardenlinux/actions/workflows/manual_gh_release_page.yml)
+2. Click "Run workflow"
+3. Select `main` branch
+4. Set Build workflow run ID to `BUILD-RUN-ID` (e.g. `23802291489`)
+
+:::warning
+Always review the generated release notes before publishing, especially the "Changes" section.
+
+The "Changes" section lists:
+
+- Upgraded packages in the minor release
+- Fixed CVEs
+
+This data is generated by [glvd](https://github.com/gardenlinux/glvd) and may not be perfect. Verify:
+
+- CVE fixes match your expectations
+- Package upgrades are correctly listed
+- No unexpected changes appear
+
+:::
+
+**Tag Manifest for Non-SemVer Releases:**
+
+:::warning
+For releases that do not use semantic versioning (e.g., `1877.5`), add an extra tag for compatibility with Gardener (especially for USI images).
+
+```bash
+# Example: Tag 1877.5 as 1877.5.0
+oras tag ghcr.io/gardenlinux/gardenlinux:1877.5 1877.5.0
+```
+
+:::
+
+### Step 4: [ONLY FOR MAJOR RELEASES] Create rel-MAJOR Branch in repo
+
+:::danger
+This step only applies to new major releases, not minor releases.
+:::
+
+Create a release branch in the `gardenlinux/repo` repository based on the new release tag:
+
+```bash
+cd /path/to/repo
+git pull --tags
+git checkout MAJOR.0.0
+git checkout -b rel-MAJOR
+git push -u origin rel-MAJOR
+```
+
+Example:
+
+```bash
+cd /path/to/repo
+git pull --tags
+git checkout 2150.0.0
+git checkout -b rel-2150
+git push -u origin rel-2150
+```
+
+This branch is used for creating future minor releases of the APT repository.
+
+### Step 5: Generate CPE File
+
+Generate the Common Platform Enumeration (CPE) file for the new release:
+
+```bash
+# Run from main branch
+gh workflow run "Generate and upload CPE to a release" \
+--ref main \
+-f version=MAJOR.MINOR.0
+
+# Example:
+gh workflow run "Generate and upload CPE to a release" \
+--ref main \
+-f version=2150.1.0
+```
+
+Or via GitHub UI:
+
+1. Go to [Actions → Generate and upload CPE](https://github.com/gardenlinux/gardenlinux/actions/workflows/cpe.yml)
+2. Click "Run workflow"
+3. Select `main` branch
+4. Set version to `MAJOR.MINOR.0`
+
+### Step 6: Update Garden Linux Documentation
+
+:::info
+TODO: add steps on how to update the documentation
+:::
+
+## Phase 2: Post-Release Work
+
+### Verify Release Completeness
+
+- Verify the GitHub release page is complete and accurate
+- Check that all expected artifacts are attached to the release
+- Confirm the CPE file was generated and uploaded
+- Test installation using the new release
+
+### Notify Stakeholders
+
+- Notify relevant teams about the new release
+- Gardener OS Extension Team
+- Update any documentation referencing supported versions
+
+## Related Topics
+
+<RelatedTopics />

--- a/docs/how-to/package-releases.md
+++ b/docs/how-to/package-releases.md
@@ -1,6 +1,6 @@
 ---
 title: Creating Package Releases
-description: Comprehensive guide to creating Garden Linux Package releases
+description: Complete guide to creating Garden Linux Package releases
 order: 1
 related_topics:
   - /explanation/release-hierarchy.md
@@ -40,7 +40,7 @@ This document is about the first tier, the [Packaging](/explanation/packaging).
 
 ## Understanding Packaging
 
-Please read the [Packaging Explanation](/explanation/packaging.md) to get familiar with the concepts of Packaging.
+Read the [Packaging Explanation](/explanation/packaging.md) to get familiar with the concepts of Packaging.
 
 ## Prerequisites
 
@@ -96,7 +96,7 @@ No manual action is required for major release APT repositories.
 
 **For Minor Releases:**
 
-Follow the comprehensive guide: [Creating APT Repository Releases](/how-to/releases/apt-repos.md)
+Follow the complete guide: [Creating APT Repository Releases](/how-to/releases/apt-repos.md)
 
 Quick summary:
 

--- a/docs/how-to/patching.md
+++ b/docs/how-to/patching.md
@@ -28,7 +28,7 @@ github_target_path: docs/how-to/packaging/patching.md
 
 This guide covers how to create and manage patches for Garden Linux packages, following the best practices from [PATCHING.MD](https://github.com/gardenlinux/package-build/blob/main/PATCHING.MD).
 
-## When to Create Patches
+## When to create patches
 
 Patches are needed when:
 
@@ -47,7 +47,7 @@ To create patches, you need:
 - Access to the package repository
 - Basic understanding of quilt
 
-## Step1: Prepare Your Local Sources
+## Step1: Prepare your local sources
 
 First, you need the complete package sources with all patches applied exactly as the GitHub Actions pipeline would do.
 
@@ -70,7 +70,7 @@ If building for arm64, include `--arch arm64` in the build command. Cross-build 
 If the source build fails to apply a patch, the sources are kept in the state where the process stopped, allowing you to fix the issue.
 :::
 
-## Step2: Spawn a Patch Environment
+## Step2: Spawn a patch environment
 
 Use the edit mode to spawn a container with quilt already configured correctly:
 
@@ -82,7 +82,7 @@ This starts a Debian container with the output folder from the previous step mou
 
 The preparation is defined in [package-build/bin/patchenv-init](https://github.com/gardenlinux/package-build/blob/main/bin/patchenv-init), so you can review those settings and use your local machine if preferred.
 
-## Step3: Make Your Changes
+## Step3: Make your changes
 
 When working on patches, keep the `a` directory unchanged and make all your changes in the `b` directory. This allows you to create a proper diff between the original and modified sources.
 
@@ -103,13 +103,13 @@ Quilt is the recommended tool for managing patches. Key commands:
 Use `quilt series` to see all patches in order and `quilt applied` to see which are already applied.
 :::
 
-### External Quilt References
+### External Quilt references
 
 - [Debian Wiki: Using Quilt](https://wiki.debian.org/UsingQuilt) - Official guide
 - [Quilt Tutorial](http://www.shakthimaan.com/downloads/glv/quilt-tutorial/quilt-doc.pdf) - Comprehensive tutorial (GNU FDL licensed)
 - [Refresh a patch that failed to apply](https://wiki.debian.org/UsingQuilt#Refresh_a_patch_that_failed_to_apply) - Debian guide for fixing broken patches
 
-## Step4: Create the Patch
+## Step4: Create the patch
 
 The diff between the original `a` directory and your modified `b` directory becomes your patch.
 
@@ -126,7 +126,7 @@ diff -Naur a/path/to/file b/path/to/file > fixes_debian/my-fix.patch
 
 :::
 
-## Step5: Add the Patch to the Package
+## Step5: Add the patch to the package
 
 Depending on the type of patch, place it in the appropriate directory and update the `prepare_source` script.
 
@@ -165,7 +165,7 @@ echo "<name-of-your-patch>" >> fixes_debian/series
 The `series` file lists all patches in the order they should be applied.
 :::
 
-## Patch Organization
+## Patch organization
 
 Follow these conventions for patch organization:
 
@@ -176,6 +176,6 @@ Follow these conventions for patch organization:
 | build dependency patches    | `fixes_build_dep`     | `apply_patches`            |
 | local customization patches | `gardenlinux_patches` | `import_upstream_patches#` |
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/patching.md
+++ b/docs/how-to/patching.md
@@ -1,0 +1,181 @@
+---
+title: Patching
+description: Learn how to create and update Patches for Garden Linux Packages
+order: 2
+related_topics:
+  - /explanation/packaging.md
+  - /explanation/package-sources.md
+  - /how-to/releases/package-releases.md
+  - /how-to/packaging/local-build.md
+  - /how-to/packaging/github-actions.md
+  - /how-to/packaging/creating-packages.md
+  - /how-to/packaging/backporting.md
+  - /how-to/packaging/patching.md
+  - /how-to/packaging/build-dependencies.md
+  - /how-to/packaging/null-releases.md
+  - /reference/packaging-rules.md
+migration_status: "done"
+migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
+migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
+migration_approved: false
+github_org: gardenlinux
+github_repo: package-build
+github_source_path: docs/how-to/patching.md
+github_target_path: docs/how-to/packaging/patching.md
+---
+
+# Patching
+
+This guide covers how to create and manage patches for Garden Linux packages, following the best practices from [PATCHING.MD](https://github.com/gardenlinux/package-build/blob/main/PATCHING.MD).
+
+## When to Create Patches
+
+Patches are needed when:
+
+- Fixing bugs in upstream source code
+- Applying security fixes from upstream to older versions
+- Customizing package behavior for Garden Linux
+- Updating the debian/ folder configuration
+- Backporting features or fixes to a specific version
+
+## Prerequisites
+
+To create patches, you need:
+
+- The `package-build` tools installed locally
+- Git
+- Access to the package repository
+- Basic understanding of quilt
+
+## Step1: Prepare Your Local Sources
+
+First, you need the complete package sources with all patches applied exactly as the GitHub Actions pipeline would do.
+
+```bash
+./package-build/build --leave-artifacts --source-only package-<package_name>
+```
+
+This command:
+
+- Calls the `package-build/bin/source` script in a container
+- Places the source in `package-<package_name>/output/run-<datetime>/a`
+- Creates a copy in `package-<package_name>/output/run-<datetime>/b`
+- Keeps the sources even if patch application fails
+
+:::warning
+If building for arm64, include `--arch arm64` in the build command. Cross-build for generating sources may cause issues.
+:::
+
+:::info
+If the source build fails to apply a patch, the sources are kept in the state where the process stopped, allowing you to fix the issue.
+:::
+
+## Step2: Spawn a Patch Environment
+
+Use the edit mode to spawn a container with quilt already configured correctly:
+
+```bash
+./package-build/build --edit package-<package_name>
+```
+
+This starts a Debian container with the output folder from the previous step mounted. The container has quilt pre-configured according to Debian standards, which is important for maintaining compatibility with patches pulled from salsa.debian.org.
+
+The preparation is defined in [package-build/bin/patchenv-init](https://github.com/gardenlinux/package-build/blob/main/bin/patchenv-init), so you can review those settings and use your local machine if preferred.
+
+## Step3: Make Your Changes
+
+When working on patches, keep the `a` directory unchanged and make all your changes in the `b` directory. This allows you to create a proper diff between the original and modified sources.
+
+### Using Quilt
+
+Quilt is the recommended tool for managing patches. Key commands:
+
+| Command               | Description                           |
+| --------------------- | ------------------------------------- |
+| `quilt push`          | Apply a single patch                  |
+| `quilt push -a`       | Apply all patches                     |
+| `quilt push -f`       | Force apply patches                   |
+| `quilt refresh`       | Update patch files after manual edits |
+| `quilt add <file>`    | Add a new file to be patched          |
+| `quilt remove <file>` | Remove a file from the patch          |
+
+:::tip
+Use `quilt series` to see all patches in order and `quilt applied` to see which are already applied.
+:::
+
+### External Quilt References
+
+- [Debian Wiki: Using Quilt](https://wiki.debian.org/UsingQuilt) - Official guide
+- [Quilt Tutorial](http://www.shakthimaan.com/downloads/glv/quilt-tutorial/quilt-doc.pdf) - Comprehensive tutorial (GNU FDL licensed)
+- [Refresh a patch that failed to apply](https://wiki.debian.org/UsingQuilt#Refresh_a_patch_that_failed_to_apply) - Debian guide for fixing broken patches
+
+## Step4: Create the Patch
+
+The diff between the original `a` directory and your modified `b` directory becomes your patch.
+
+```bash
+diff -Naur a/ b/ > <name-of-your-patch>.patch
+```
+
+:::tip
+If you know which file was modified, create a focused patch:
+
+```bash
+diff -Naur a/path/to/file b/path/to/file > fixes_debian/my-fix.patch
+```
+
+:::
+
+## Step5: Add the Patch to the Package
+
+Depending on the type of patch, place it in the appropriate directory and update the `prepare_source` script.
+
+### For debian/ folder patches
+
+Place patches in a `fixes_debian` directory and apply them in `prepare_source`:
+
+```bash
+apply_patches fixes_debian
+```
+
+### For upstream source patches
+
+Place patches in an `upstream_patches` directory and import them in `prepare_source`:
+
+```bash
+import_upstream_patches# upstream_patches
+```
+
+### Creating the directory
+
+If the directory doesn't exist, create it and add the patch:
+
+```bash
+mkdir -p fixes_debian
+mv <name-of-your-patch>.patch fixes_debian/
+```
+
+Then add the patch to the series file:
+
+```bash
+echo "<name-of-your-patch>" >> fixes_debian/series
+```
+
+:::info
+The `series` file lists all patches in the order they should be applied.
+:::
+
+## Patch Organization
+
+Follow these conventions for patch organization:
+
+| Patch Type                  | Directory             | Application Method         |
+| --------------------------- | --------------------- | -------------------------- |
+| debian/ folder changes      | `fixes_debian`        | `apply_patches`            |
+| upstream source changes     | `upstream_patches`    | `import_upstream_patches#` |
+| build dependency patches    | `fixes_build_dep`     | `apply_patches`            |
+| local customization patches | `gardenlinux_patches` | `import_upstream_patches#` |
+
+## Related Topics
+
+<RelatedTopics />

--- a/docs/how-to/remove-packages.md
+++ b/docs/how-to/remove-packages.md
@@ -1,0 +1,88 @@
+---
+title: Removing Packages from Repository
+description: Procedure to switch back to Debian-provided packages instead of Garden Linux-built packages
+order: 8
+related_topics:
+  - /explanation/release-hierarchy.md
+  - /explanation/packaging.md
+  - /explanation/package-sources.md
+  - /explanation/repo-infrastructure.md
+  - /explanation/os-releases.md
+  - /explanation/semver.md
+  - /how-to/releases/package-releases.md
+  - /how-to/packaging/local-build.md
+  - /how-to/packaging/github-actions.md
+  - /how-to/packaging/creating-packages.md
+  - /how-to/packaging/backporting.md
+  - /how-to/packaging/patching.md
+  - /how-to/packaging/build-dependencies.md
+  - /how-to/packaging/null-releases.md
+  - /reference/packaging-rules.md
+migration_status: "done"
+migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
+migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
+migration_approved: false
+github_org: gardenlinux
+github_repo: package-build
+github_source_path: docs/how-to/remove-packages.md
+github_target_path: docs/how-to/packaging/remove-packages.md
+---
+
+# Removing Packages from Repository
+
+There may be cases where we need to switch back to using Debian-provided packages instead of Garden Linux-built packages.
+
+## Important Considerations
+
+:::danger
+DO NOT RENAME PACKAGE REPOS
+
+Renaming package repositories will break future patch releases, as the `package-releases` file references repositories by their exact names. Additionally, you should disable GitHub Actions for the repository to prevent version updates from overwriting the null release.
+:::
+
+## Procedure to Nullify a Package
+
+To remove a Garden Linux package and revert to the Debian version:
+
+1. **Create an archive branch**
+
+   ```bash
+   git checkout -b archive-<PACKAGE_NAME>
+   ```
+
+2. **Disable GitHub Actions and remove files**
+
+   ```bash
+   git rm -r .github/workflows
+   git rm -r <ALL_FILES>
+   ```
+
+3. **Create a README documenting the package**
+
+   ```bash
+   git add README.md
+   git commit -a -m "null"
+   git push -u origin archive-<PACKAGE_NAME>
+   ```
+
+4. **Create the null tag and release**
+
+   ```bash
+   git tag null
+   git push origin null
+
+   # Create a non-empty file for the release (required by GitHub)
+   echo null > ~/null
+   gh release create null ~/null --latest --notes null --title 'ignore package for repo import'
+   ```
+
+5. **Archive the repository in GitHub**
+   - Go to: `github.com/gardenlinux/package-<NAME>_repo`
+   - Navigate to Settings → Danger Zone → Archive
+
+This process ensures that:
+
+- The package repository is preserved for historical reference
+- No new builds will be triggered for the package
+- The `repo` will import the package from Debian instead of using a Garden Linux build
+- Future patch releases for the Garden Linux version will continue to work correctly

--- a/docs/how-to/remove-packages.md
+++ b/docs/how-to/remove-packages.md
@@ -32,15 +32,15 @@ github_target_path: docs/how-to/packaging/remove-packages.md
 
 There may be cases where we need to switch back to using Debian-provided packages instead of Garden Linux-built packages.
 
-## Important Considerations
+## Important considerations
 
 :::danger
 DO NOT RENAME PACKAGE REPOS
 
-Renaming package repositories will break future patch releases, as the `package-releases` file references repositories by their exact names. Additionally, you should disable GitHub Actions for the repository to prevent version updates from overwriting the null release.
+Renaming package repositories will break future patch releases, as the `package-releases` file references repositories by their exact names. Also, you should disable GitHub Actions for the repository to prevent version updates from overwriting the null release.
 :::
 
-## Procedure to Nullify a Package
+## Procedure to nullify a package
 
 To remove a Garden Linux package and revert to the Debian version:
 

--- a/docs/reference/packaging-rules.md
+++ b/docs/reference/packaging-rules.md
@@ -1,0 +1,192 @@
+---
+title: Packaging Rules
+description: Reference of all authoritative Garden Linux Packaging Rules
+related_topics:
+  - /explanation/release-hierarchy.md
+  - /explanation/packaging.md
+  - /explanation/package-sources.md
+  - /explanation/repo-infrastructure.md
+  - /explanation/os-releases.md
+  - /explanation/semver.md
+  - /how-to/releases/package-releases.md
+  - /how-to/packaging/local-build.md
+  - /how-to/packaging/github-actions.md
+  - /how-to/packaging/creating-packages.md
+  - /how-to/packaging/backporting.md
+  - /how-to/packaging/patching.md
+  - /how-to/packaging/build-dependencies.md
+  - /how-to/packaging/null-releases.md
+  - /reference/packaging-rules.md
+migration_status: "done"
+migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
+migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
+migration_approved: false
+github_org: gardenlinux
+github_repo: package-build
+github_source_path: docs/reference/packaging-rules.md
+github_target_path: docs/reference/packaging-rules.md
+---
+
+# Packaging Rules
+
+This reference document outlines the authoritative rules for creating and maintaining Garden Linux packages. These rules ensure consistency, security, and maintainability across the package ecosystem.
+
+## Package Repository Naming
+
+To ensure clear identification and standardized tooling, package repositories follow a strict naming convention.
+
+### Rule 1: Package repositories must be named accordingly
+
+```
+package-<package-source>
+```
+
+- **Must start with** `package-`
+- `<package-source>` **must be** the name of the source package as defined in Debian
+- **Exception**: If the package does not exist in Debian, use the upstream source name
+
+**Examples**:
+
+- `package-containerd` - Containerd from Debian
+- `package-openssl` - OpenSSL from Debian
+- `package-metalbond` - Metalbond (not in Debian)
+- `package-iproute2` - iproute2 from Debian
+
+### Rule 2: One-shot build dependency repositories must start with bp-package
+
+Package repositories required only as a build dependency for another backported package must start with `bp-package-*`.
+
+**Examples**:
+
+- `bp-package-xyz-0.0.1` - Build dependency only needed for package-ABC
+- `bp-package-libfoo-1.2.3` - Build dependency for a backported library
+
+## Git Branch Naming
+
+Branch names in package repositories follow standardized patterns to indicate their purpose and compatibility.
+
+### Rule 3: Git branches must be named accordingly
+
+**Branch types**:
+
+- `main`: Builds against the latest Garden Linux environment
+- `rel-<MAJOR>`: Builds against `<MAJOR>` version of Garden Linux (e.g., `rel-2150`)
+- `fix/*`, `feat/*`, `chore/*`, `doc/*`: Temporary branches for work in progress
+
+**Branch purpose**:
+
+- The `main` branch is used for regular builds and nightly releases
+- `rel-<MAJOR>` branches are used for backporting packages to specific major versions
+- Temporary branches (`fix/*`, `feat/*`) are for development work and should be deleted after merging
+
+## Source Acquisition
+
+### Rule 4: Get debian/ folder from Garden Linux snapshot apt repository
+
+For existing Debian packages, obtain the `debian/` folder from the Garden Linux snapshot apt repository.
+
+The `apt_src` helper function must be used in the `prepare_source` script:
+
+```bash
+apt_src --ignore_orig <source_package_name>
+```
+
+:::tip
+All Debian packages from testing are mirrored daily in a Garden Linux snapshot apt repository. If a source package is missing in a snapshot, the Debian salsa repository may be used instead.
+:::
+
+**Recommended workflow**:
+
+1. Check `https://packages.gardenlinux.io/debian-release.snapshot/` for the package
+2. If present, use `apt_src`
+3. If not present, check salsa.debian.org for current debian/ folder
+4. Use `git_src` to get from salsa if needed
+
+## Package Creation
+
+### Rule 5: Create debian/ folder only if Debian package does not exist
+
+If there is **no existing Debian package**, the `debian/` folder must be created manually and checked into the `package-` repository.
+
+This applies to:
+
+- Packages not available in Debian at all
+- Upstream-only software
+- Custom patches that significantly alter the package
+
+The `debian/` folder should include:
+
+- `control` file with package metadata
+- `copyright` file
+- `rules` file
+- `source/format`
+- Appropriate patches in `patches/`
+
+## Upstream Source
+
+### Rule 6: Get upstream source from upstream git repository
+
+To enable automatic upstream version tracking, get source code directly from the upstream git repository, not from Debian source packages or patches.
+
+This allows automatic triggering of builds when new upstream versions are available without waiting for Debian maintainers to update salsa.
+
+The `git_src` helper function must be used in the `prepare_source` script:
+
+```bash
+version_orig=<VERSION>
+git_src --branch <BRANCH_NAME> <GIT_REPO_URL>
+```
+
+**Examples**:
+
+```bash
+# OpenSSL from upstream git
+git_src --branch "openssl-$version_orig" https://github.com/openssl/openssl.git
+
+# iproute2 from Debian salsa
+git_src -b "debian/$version" https://salsa.debian.org/debian/iproute2.git
+```
+
+## Patching
+
+### Rule 7: Patching the debian/ folder
+
+Changes to files in the `debian/` folder should be made as patches, not by direct edits. The `debian/patches` folder is treated as source code.
+
+Patches for the debian folder should be placed in a `fixes_debian` folder and applied with the `apply_patches` helper function.
+
+**Example**:
+
+```bash
+# In prepare_source script
+apply_patches fixes_debian
+```
+
+**Workflow to create a debian patch**:
+
+1. Build sources with `build --leave-artifacts`
+2. Spawn patch environment with `build --edit`
+3. Make changes in the `b` directory using quilt
+4. Create patch with `diff -Naur a/debian b/debian > fixes_debian/your-fix.patch`
+5. Add patch to `fixes_debian/series`
+
+### Rule 8: Append to debian/patches for upstream patches
+
+Patches for upstream source code should be placed in an `upstream_patches` folder and applied using the `import_upstream_patches` helper function.
+
+This function copies patches to `debian/patches` and appends them to `debian/patches/series`, enabling easy maintenance of patches from upstream sources.
+
+**Example**:
+
+```bash
+# In prepare_source script
+import_upstream_patches# upstream_patches
+```
+
+:::tip
+This approach allows convenient import and maintenance of patches from upstream (e.g., cherry-picking an upstream commit on a different branch to fix a CVE).
+:::
+
+## Related Topics
+
+<RelatedTopics />

--- a/docs/reference/packaging-rules.md
+++ b/docs/reference/packaging-rules.md
@@ -31,7 +31,7 @@ github_target_path: docs/reference/packaging-rules.md
 
 This reference document outlines the authoritative rules for creating and maintaining Garden Linux packages. These rules ensure consistency, security, and maintainability across the package ecosystem.
 
-## Package Repository Naming
+## Package repository naming
 
 To ensure clear identification and standardized tooling, package repositories follow a strict naming convention.
 
@@ -61,7 +61,7 @@ Package repositories required only as a build dependency for another backported 
 - `bp-package-xyz-0.0.1` - Build dependency only needed for package-ABC
 - `bp-package-libfoo-1.2.3` - Build dependency for a backported library
 
-## Git Branch Naming
+## Git branch naming
 
 Branch names in package repositories follow standardized patterns to indicate their purpose and compatibility.
 
@@ -79,7 +79,7 @@ Branch names in package repositories follow standardized patterns to indicate th
 - `rel-<MAJOR>` branches are used for backporting packages to specific major versions
 - Temporary branches (`fix/*`, `feat/*`) are for development work and should be deleted after merging
 
-## Source Acquisition
+## Source acquisition
 
 ### Rule 4: Get debian/ folder from Garden Linux snapshot apt repository
 
@@ -102,7 +102,7 @@ All Debian packages from testing are mirrored daily in a Garden Linux snapshot a
 3. If not present, check salsa.debian.org for current debian/ folder
 4. Use `git_src` to get from salsa if needed
 
-## Package Creation
+## Package creation
 
 ### Rule 5: Create debian/ folder only if Debian package does not exist
 
@@ -122,7 +122,7 @@ The `debian/` folder should include:
 - `source/format`
 - Appropriate patches in `patches/`
 
-## Upstream Source
+## Upstream source
 
 ### Rule 6: Get upstream source from upstream git repository
 
@@ -187,6 +187,6 @@ import_upstream_patches# upstream_patches
 This approach allows convenient import and maintenance of patches from upstream (e.g., cherry-picking an upstream commit on a different branch to fix a CVE).
 :::
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes: https://github.com/gardenlinux/gardenlinux/issues/4807

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
