### PR TITLE
docs: remove "AI-generated phrasing"

### DIFF
--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -111,7 +111,7 @@ Since prepare_source is invoked directly in the package-build pipeline as step i
 
 ### Get debian/ folder
 
-The debian folder contains patches, configurations and rules to make and install the software. For more details about the required content of that debian folder, please read [debian documentation](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html).
+The debian folder contains patches, configurations and rules to make and install the software. For more details about the required content of that debian folder, read [debian documentation](https://www.debian.org/doc/manuals/maint-guide/dreq.en.html).
 
 To create a Garden Linux package, we also need a **debian/ folder** including all the required files.
 In the following we define how we **SHOULD** get the debian folder, depending on the case:
@@ -161,7 +161,7 @@ git_src --branch <BRANCH NAME> <GIT_REPO_URL>
 Garden Linux Patches are applied on top of debian patches. 
 
 > [!WARNING]
-> please see patching guide --- insert link here --- 
+> see patching guide --- insert link here --- 
 
 #### Rule 7: Patching debian patches 
 We consider the debian/patches folder as source, and changes to debian/patches are done and tracked via patches. 
@@ -238,7 +238,7 @@ Packages for patch releases are also uploaded to the GitHub Release page, but mu
 If a package-XYZ build must be excluded in next nightly apt repositories, a so called "NULL release" must be published for package-XYZ. 
 
 > [!IMPORTANT]
-> If you want to remove/archive a package from Garden Linux by creating a null release, please follow this [guide](https://github.com/gardenlinux/repo?tab=readme-ov-file#remove-garden-linux-packages-from-the-repo).
+> If you want to remove/archive a package from Garden Linux by creating a null release, follow this [guide](https://github.com/gardenlinux/repo?tab=readme-ov-file#remove-garden-linux-packages-from-the-repo).
 
 ### What happens under the hood
 The [fetch_releases](https://github.com/gardenlinux/repo/blob/main/fetch_releases) script runs as part of the github actions of gardenlinux/repo. 

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -208,7 +208,7 @@ The central gardenlinux/package-build repo contains reusable actions, that are u
 Input for this stage is a debian source package created by the previous stage.
 The central gardenlinux/package-build repo contains reusable actions, that are used to automatically perform this step, as well. 
 
-You can add a `prepare_binary` script to the package-XYZ repo to additionally perform some preparations before the binary build step is executed. 
+You can add a `prepare_binary` script to the package-XYZ repo to perform additional preparations before the binary build step is executed. 
 You could for example reconfigure debian build profiles, install build dependencies or add some logging flags for debugging.
 
 # Test binary package 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To find our more, visit our
 ## Licensing
 
 Copyright 2025 SAP SE or an SAP affiliate company and GardenLinux contributors.
-Please see our [LICENSE](LICENSE) for copyright and license information.
+See our [LICENSE](LICENSE) for copyright and license information.
 Detailed information including third-party components and their
 licensing/copyright information is available
 [via the REUSE tool](https://reuse.software).

--- a/docs/explanation/package-sources.md
+++ b/docs/explanation/package-sources.md
@@ -57,6 +57,6 @@ Packages with native sources are used when:
 
 - The source code is developed and maintained by the Garden Linux developers, so Debian does not package it
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/explanation/packaging.md
+++ b/docs/explanation/packaging.md
@@ -32,7 +32,7 @@ github_target_path: docs/explanation/packaging.md
 
 This document explains how Garden Linux packages are built using the tools in the `package-build` repository and how they fit into the broader packaging ecosystem.
 
-## Release Hierarchy
+## Release hierarchy
 
 Garden Linux uses a [three-tier release hierarchy](/explanation/release-hierarchy.md) to deliver a complete operating system.
 
@@ -58,7 +58,7 @@ Each custom-built package has its own GitHub repository following the naming con
 
 These repositories are built using the tools in the `package-build` repository.
 
-## Package Flow Process Overview
+## Package flow process overview
 
 1. **Source Management**: Package source lives in `package-{package_name}` repos
 2. **Building**: Packages are built using tools from `package-build` repo
@@ -66,14 +66,14 @@ These repositories are built using the tools in the `package-build` repository.
 3. **Release Assembly**: Built packages are collected and assembled into APT repositories by the `repo` workflow
 4. **Distribution**: Final APT repository is published and made available to users
 
-## Key Relationships
+## Key relationships
 
 - Each `package-*` repo declares its build dependencies in its source
 - The `package-build` repo provides common tooling used by all `package-*` repos
 - The [`repo`](https://github.com/gardenlinux/repo) orchestrates the final release by collecting built packages and dependencies
 - Users access packages through the standard APT system pointing to Garden Linux repositories
 
-## Understanding Package Versions
+## Understanding package versions
 
 Garden Linux packages typically follow versioning like:
 
@@ -91,6 +91,6 @@ Where:
 
 When creating patch releases or backports, the suffix is incremented (e.g., `~gardenlinux1`, `~gardenlinux2`) or modified for specific use cases (like `~bp1443` for backports).
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/backporting.md
+++ b/docs/how-to/backporting.md
@@ -34,7 +34,7 @@ This guide covers how to create patch releases and backport packages in Garden L
 
 For foundational knowledge on package creation and repository structure, see the [Packaging Rules](/reference/packaging-rules.md) reference.
 
-## Creating Patch Releases
+## Creating patch releases
 
 When running the GitHub Actions job with `release: true`, it automatically creates a new release with version suffix `gl0` (or `gardenlinux0` in older packages). To create a patch release for this version:
 
@@ -81,9 +81,9 @@ git push origin <VERSION>
 
 If the action is set up to run on `push` (as in the basic example), this will trigger the build job. The job will detect that this is a new version and create the necessary tags and GitHub releases.
 
-## Backporting Examples
+## Backporting examples
 
-### Backporting New Upstream Version Not Available (yet) on Salsa
+### Backporting new upstream version not available (yet) on Salsa
 
 When backporting a version not available (yet) in Debian salsa (e.g., OpenSSL 3.1.7), configure the `prepare_source` script as follows:
 
@@ -97,7 +97,7 @@ version_suffix=gl0~bp1443
 
 This configuration fetches source files from the upstream repository while using the Debian folder from the apt source package. If there are compatibility issues, patches may need to be added using the `apply_patches` function.
 
-### Backporting Package Already in Nightly Releases
+### Backporting package already in nightly releases
 
 For packages available in Debian testing and tracked in salsa (e.g., `jq` version `1.8.1`):
 
@@ -111,7 +111,7 @@ git_src -b "debian/$version" https://salsa.debian.org/debian/jq.git
 version_suffix=gl0+bp1877
 ```
 
-### Backporting Missing Salsa Sources (Last Resort)
+### Backporting missing Salsa sources (last resort)
 
 :::warning
 Use this method only as a last resort when source code is not available in Debian salsa or when upstream sources differ significantly. In all other cases, this method is discouraged.
@@ -140,6 +140,6 @@ snapshot_src "$pkg" "$snapshot_timestamp"
 Debian snapshots can be useful for determining when Garden Linux snapshots contain a certain package version. For example, visit https://snapshot.debian.org/package/sqlite3/3.46.1-7/ to find the date `2025-07-26`, then use `bin/garden-version --major 2025-07-26` to get `1943` as a candidate version for `snapshot_gl_version`.
 :::
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/build-dependencies.md
+++ b/docs/how-to/build-dependencies.md
@@ -69,7 +69,7 @@ The bp-package repository is **not** included in the `package-releases` file of 
 In rescent Garden Linux Release, some `bp-*` packages ended up in the `package-releases` files. Be aware of this.
 :::
 
-## Using Build Dependencies in Workflows
+## Using build dependencies in workflows
 
 Specify the build dependency in the GitHub Actions workflow of the main package using the `build_dep` parameter.
 
@@ -92,7 +92,7 @@ jobs:
 - `build_dep`: Specifies the dependency repository and version in the format `<repo> <tag>`
 - The dependency is automatically fetched and made available during the build
 
-## Complete Example
+## Complete example
 
 For a package that requires a patched version of libtool:
 
@@ -106,7 +106,7 @@ build_dep: gardenlinux/bp-package-libtool 0.0.1-0gl0+bp1
 
 The build system will automatically fetch the dependency and use it during compilation.
 
-## Important Notes
+## Important notes
 
 :::warning
 Build-time dependencies between packages are not updated automatically and need to be adjusted manually when needed.
@@ -120,6 +120,6 @@ bp-package repositories should be kept minimal and focused only on providing the
 For widely-used dependencies that will be needed by multiple packages, consider adding them to the base Garden Linux environment instead of using bp-package.
 :::
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/build-dependencies.md
+++ b/docs/how-to/build-dependencies.md
@@ -66,7 +66,7 @@ To create a bp-package repository:
 The bp-package repository is **not** included in the `package-releases` file of gardenlinux/repo, but it is included in the build of the dependent package.
 
 :::danger
-In rescent Garden Linux Release, some `bp-*` packages ended up in the `package-releases` files. Please be aware of this.
+In rescent Garden Linux Release, some `bp-*` packages ended up in the `package-releases` files. Be aware of this.
 :::
 
 ## Using Build Dependencies in Workflows

--- a/docs/how-to/creating-packages.md
+++ b/docs/how-to/creating-packages.md
@@ -125,7 +125,7 @@ For detailed patching procedures, see the [Patching](/how-to/packaging/patching.
 
 ## Step 2: Make the Source Package
 
-A source package contains all necessary files to build the binaries and serves as input for the binary build step.
+A source package contains all necessary files to build the binaries and is the input for the binary build step.
 
 The gardenlinux/package-build repository provides reusable actions to perform this step automatically. See the [build.yml workflow](https://github.com/gardenlinux/package-build/blob/621c4c8f530a93884f7b9a4dfc348a50a2d19aa5/.github/workflows/build.yml#L29) for reference.
 
@@ -184,6 +184,6 @@ Packages for patch releases are uploaded to GitHub Releases but must be manually
 
 For complete details on apt repository creation, see the [Creating APT Repository Releases](/how-to/releases/apt-repos.md) guide.
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/github-actions.md
+++ b/docs/how-to/github-actions.md
@@ -89,6 +89,6 @@ jobs:
       release: ${{ github.ref == 'refs/heads/main' }}
 ```
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -31,13 +31,13 @@ github_target_path: docs/how-to/packaging/index.md
 
 The Garden Linux packaging system enables the creation of customized operating system images through a modular approach. This guide provides an overview of the complete package release lifecycle and links to detailed how-to guides for each stage.
 
-## Release Hierarchy
+## Release hierarchy
 
 Garden Linux uses a [three-tier release hierarchy](/explanation/release-hierarchy.md) to deliver a complete operating system.
 
 This document is about the first tier, the [Packaging Ecosystem](/how-to/releases/package-releases).
 
-## Package Release Lifecycle
+## Package release lifecycle
 
 Creating and releasing packages in Garden Linux follows a structured process:
 
@@ -50,13 +50,13 @@ Creating and releasing packages in Garden Linux follows a structured process:
 5. **[Managing Dependencies](/how-to/packaging/build-dependencies.md)**: Handle special build-time dependencies with bp-package repositories
 6. **[Excluding Packages](/how-to/packaging/null-releases.md)**: Use NULL releases to temporarily exclude problematic packages from builds
 
-## Core Concepts
+## Core concepts
 
 - **[Packaging Rules](/reference/packaging-rules.md)**: Authoritative reference for all naming conventions and procedural rules
 - **[Package Sources](/explanation/package-sources.md)**: Understand the different types of package sources in Garden Linux
 - **[Repository Infrastructure](https://github.com/gardenlinux/repo/blob/main/docs/explanation/infrastructure.md)**: Learn how packages are assembled into apt repositories
 
-## Getting Started
+## Getting started
 
 1. Review the [Packaging Rules](/reference/packaging-rules.md) for naming conventions and repository structure
 2. Choose a package to work on (either a new package or modifying an existing one)

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,6 +1,6 @@
 ---
 title: Packaging
-description: Comprehensive guide to the Garden Linux packaging system and release lifecycle
+description: Complete guide to the Garden Linux packaging system and release lifecycle
 related_topics:
   - /explanation/release-hierarchy.md
   - /explanation/packaging.md

--- a/docs/how-to/local-build.md
+++ b/docs/how-to/local-build.md
@@ -28,7 +28,7 @@ github_source_path: docs/how-to/local-build.md
 github_target_path: docs/how-to/packaging/local-build.md
 ---
 
-# Local Package Building
+# Local package building
 
 This guide covers how to build Garden Linux packages locally using the `package-build` tools.
 
@@ -38,7 +38,7 @@ This guide covers how to build Garden Linux packages locally using the `package-
 - Sufficient disk space for builds
 - Access to the Garden Linux package repositories
 
-## Build Process
+## Build process
 
 ### 1. Clone the package-build repository
 
@@ -66,11 +66,11 @@ Execute the build script from the package-build repository, passing your package
 If your package build depends on other custom build packages, you can provide the `--build-dependencies` flag with a directory containing the `.deb` files of build-time dependencies.
 :::
 
-## Build Artifacts
+## Build artifacts
 
 The build artifacts (`.deb` files and others) are placed in a `.build` directory within your package repository. For example: `./package-iproute2/.build/`.
 
-## Build Options
+## Build options
 
 The `build` script supports several options to customize the build process:
 
@@ -81,6 +81,6 @@ The `build` script supports several options to customize the build process:
 - `--build-dependencies`: Path to a directory containing `.deb` files to be used as build-time dependencies
 - `--edit`: Spawn a gardenlinux/repo-debian-snapshort container with `package-XYZ/output` mounted, quilt installed and configured
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/null-releases.md
+++ b/docs/how-to/null-releases.md
@@ -43,7 +43,7 @@ NULL releases are used to:
 - Exclude packages with licensing or security issues
 - Mark deprecated packages
 
-## How NULL Releases Work
+## How NULL releases work
 
 The null release mechanism operates through several components in the Garden Linux infrastructure:
 

--- a/docs/how-to/null-releases.md
+++ b/docs/how-to/null-releases.md
@@ -93,7 +93,7 @@ to re-enable a package that was previously disabled with a NULL release, you hav
 ## Important Considerations
 
 :::danger
-If you want to permanently remove/archive a package from Garden Linux, please follow the [official guide](https://github.com/gardenlinux/repo?tab=readme-ov-file#remove-garden-linux-packages-from-the-repo) in the gardenlinux/repo repository.
+If you want to permanently remove/archive a package from Garden Linux, follow the [official guide](https://github.com/gardenlinux/repo?tab=readme-ov-file#remove-garden-linux-packages-from-the-repo) in the gardenlinux/repo repository.
 :::
 
 :::warning

--- a/docs/how-to/package-releases.md
+++ b/docs/how-to/package-releases.md
@@ -28,17 +28,17 @@ github_source_path: docs/how-to/package-releases.md
 github_target_path: docs/how-to/releases/package-releases.md
 ---
 
-# Creating Package Releases
+# Creating package releases
 
 This guide explains how to create Garden Linux Package releases.
 
-## Release Hierarchy
+## Release hierarchy
 
 Garden Linux uses a [three-tier release hierarchy](/explanation/release-hierarchy.md) to deliver a complete operating system.
 
 This document is about the first tier, the [Packaging](/explanation/packaging).
 
-## Understanding Packaging
+## Understanding packaging
 
 Read the [Packaging Explanation](/explanation/packaging.md) to get familiar with the concepts of Packaging.
 
@@ -51,7 +51,7 @@ Before creating an OS release, ensure you have:
 
 ## Phase 0: Preparation
 
-### Step 1: Decide What to Include
+### Step 1: Decide what to include
 
 In tier one, individual [packages](/explanation/packaging.md) will need updates based on e.g. recent CVEs. Check for potential upgrades in important packages, too:
 
@@ -77,9 +77,9 @@ The complexity of updating a package varies:
 
 For complex updates, thoroughly test the new package version before including it in a release.
 
-## Phase 1: Creating the Release
+## Phase 1: Creating the release
 
-### Step 1: Create APT Repository Release
+### Step 1: Create APT repository release
 
 In tier two, the [APT repository](/explanation/repo-infrastructure.md) must be created before building OS images.
 
@@ -196,7 +196,7 @@ gh workflow run nightly.yml \
 - Verify all build jobs complete successfully
 - Check that artifacts are published
 
-### Step 3: Create GitHub Release
+### Step 3: Create GitHub release
 
 After the build completes, create the official GitHub release page:
 
@@ -284,7 +284,7 @@ git push -u origin rel-2150
 
 This branch is used for creating future minor releases of the APT repository.
 
-### Step 5: Generate CPE File
+### Step 5: Generate CPE file
 
 Generate the Common Platform Enumeration (CPE) file for the new release:
 
@@ -307,27 +307,27 @@ Or via GitHub UI:
 3. Select `main` branch
 4. Set version to `MAJOR.MINOR.0`
 
-### Step 6: Update Garden Linux Documentation
+### Step 6: Update Garden Linux documentation
 
 :::info
 TODO: add steps on how to update the documentation
 :::
 
-## Phase 2: Post-Release Work
+## Phase 2: Post-release work
 
-### Verify Release Completeness
+### Verify release completeness
 
 - Verify the GitHub release page is complete and accurate
 - Check that all expected artifacts are attached to the release
 - Confirm the CPE file was generated and uploaded
 - Test installation using the new release
 
-### Notify Stakeholders
+### Notify stakeholders
 
 - Notify relevant teams about the new release
 - Gardener OS Extension Team
 - Update any documentation referencing supported versions
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/package-releases.md
+++ b/docs/how-to/package-releases.md
@@ -1,6 +1,6 @@
 ---
 title: Creating Package Releases
-description: Comprehensive guide to creating Garden Linux Package releases
+description: Complete guide to creating Garden Linux Package releases
 order: 1
 related_topics:
   - /explanation/release-hierarchy.md
@@ -40,7 +40,7 @@ This document is about the first tier, the [Packaging](/explanation/packaging).
 
 ## Understanding Packaging
 
-Please read the [Packaging Explanation](/explanation/packaging.md) to get familiar with the concepts of Packaging.
+Read the [Packaging Explanation](/explanation/packaging.md) to get familiar with the concepts of Packaging.
 
 ## Prerequisites
 
@@ -96,7 +96,7 @@ No manual action is required for major release APT repositories.
 
 **For Minor Releases:**
 
-Follow the comprehensive guide: [Creating APT Repository Releases](/how-to/releases/apt-repos.md)
+Follow the complete guide: [Creating APT Repository Releases](/how-to/releases/apt-repos.md)
 
 Quick summary:
 

--- a/docs/how-to/patching.md
+++ b/docs/how-to/patching.md
@@ -28,7 +28,7 @@ github_target_path: docs/how-to/packaging/patching.md
 
 This guide covers how to create and manage patches for Garden Linux packages, following the best practices from [PATCHING.MD](https://github.com/gardenlinux/package-build/blob/main/PATCHING.MD).
 
-## When to Create Patches
+## When to create patches
 
 Patches are needed when:
 
@@ -47,7 +47,7 @@ To create patches, you need:
 - Access to the package repository
 - Basic understanding of quilt
 
-## Step1: Prepare Your Local Sources
+## Step1: Prepare your local sources
 
 First, you need the complete package sources with all patches applied exactly as the GitHub Actions pipeline would do.
 
@@ -70,7 +70,7 @@ If building for arm64, include `--arch arm64` in the build command. Cross-build 
 If the source build fails to apply a patch, the sources are kept in the state where the process stopped, allowing you to fix the issue.
 :::
 
-## Step2: Spawn a Patch Environment
+## Step2: Spawn a patch environment
 
 Use the edit mode to spawn a container with quilt already configured correctly:
 
@@ -82,7 +82,7 @@ This starts a Debian container with the output folder from the previous step mou
 
 The preparation is defined in [package-build/bin/patchenv-init](https://github.com/gardenlinux/package-build/blob/main/bin/patchenv-init), so you can review those settings and use your local machine if preferred.
 
-## Step3: Make Your Changes
+## Step3: Make your changes
 
 When working on patches, keep the `a` directory unchanged and make all your changes in the `b` directory. This allows you to create a proper diff between the original and modified sources.
 
@@ -103,13 +103,13 @@ Quilt is the recommended tool for managing patches. Key commands:
 Use `quilt series` to see all patches in order and `quilt applied` to see which are already applied.
 :::
 
-### External Quilt References
+### External Quilt references
 
 - [Debian Wiki: Using Quilt](https://wiki.debian.org/UsingQuilt) - Official guide
 - [Quilt Tutorial](http://www.shakthimaan.com/downloads/glv/quilt-tutorial/quilt-doc.pdf) - Comprehensive tutorial (GNU FDL licensed)
 - [Refresh a patch that failed to apply](https://wiki.debian.org/UsingQuilt#Refresh_a_patch_that_failed_to_apply) - Debian guide for fixing broken patches
 
-## Step4: Create the Patch
+## Step4: Create the patch
 
 The diff between the original `a` directory and your modified `b` directory becomes your patch.
 
@@ -126,7 +126,7 @@ diff -Naur a/path/to/file b/path/to/file > fixes_debian/my-fix.patch
 
 :::
 
-## Step5: Add the Patch to the Package
+## Step5: Add the patch to the package
 
 Depending on the type of patch, place it in the appropriate directory and update the `prepare_source` script.
 
@@ -165,7 +165,7 @@ echo "<name-of-your-patch>" >> fixes_debian/series
 The `series` file lists all patches in the order they should be applied.
 :::
 
-## Patch Organization
+## Patch organization
 
 Follow these conventions for patch organization:
 
@@ -176,6 +176,6 @@ Follow these conventions for patch organization:
 | build dependency patches    | `fixes_build_dep`     | `apply_patches`            |
 | local customization patches | `gardenlinux_patches` | `import_upstream_patches#` |
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />

--- a/docs/how-to/remove-packages.md
+++ b/docs/how-to/remove-packages.md
@@ -32,15 +32,15 @@ github_target_path: docs/how-to/packaging/remove-packages.md
 
 There may be cases where we need to switch back to using Debian-provided packages instead of Garden Linux-built packages.
 
-## Important Considerations
+## Important considerations
 
 :::danger
 DO NOT RENAME PACKAGE REPOS
 
-Renaming package repositories will break future patch releases, as the `package-releases` file references repositories by their exact names. Additionally, you should disable GitHub Actions for the repository to prevent version updates from overwriting the null release.
+Renaming package repositories will break future patch releases, as the `package-releases` file references repositories by their exact names. Also, you should disable GitHub Actions for the repository to prevent version updates from overwriting the null release.
 :::
 
-## Procedure to Nullify a Package
+## Procedure to nullify a package
 
 To remove a Garden Linux package and revert to the Debian version:
 

--- a/docs/reference/packaging-rules.md
+++ b/docs/reference/packaging-rules.md
@@ -31,7 +31,7 @@ github_target_path: docs/reference/packaging-rules.md
 
 This reference document outlines the authoritative rules for creating and maintaining Garden Linux packages. These rules ensure consistency, security, and maintainability across the package ecosystem.
 
-## Package Repository Naming
+## Package repository naming
 
 To ensure clear identification and standardized tooling, package repositories follow a strict naming convention.
 
@@ -61,7 +61,7 @@ Package repositories required only as a build dependency for another backported 
 - `bp-package-xyz-0.0.1` - Build dependency only needed for package-ABC
 - `bp-package-libfoo-1.2.3` - Build dependency for a backported library
 
-## Git Branch Naming
+## Git branch naming
 
 Branch names in package repositories follow standardized patterns to indicate their purpose and compatibility.
 
@@ -79,7 +79,7 @@ Branch names in package repositories follow standardized patterns to indicate th
 - `rel-<MAJOR>` branches are used for backporting packages to specific major versions
 - Temporary branches (`fix/*`, `feat/*`) are for development work and should be deleted after merging
 
-## Source Acquisition
+## Source acquisition
 
 ### Rule 4: Get debian/ folder from Garden Linux snapshot apt repository
 
@@ -102,7 +102,7 @@ All Debian packages from testing are mirrored daily in a Garden Linux snapshot a
 3. If not present, check salsa.debian.org for current debian/ folder
 4. Use `git_src` to get from salsa if needed
 
-## Package Creation
+## Package creation
 
 ### Rule 5: Create debian/ folder only if Debian package does not exist
 
@@ -122,7 +122,7 @@ The `debian/` folder should include:
 - `source/format`
 - Appropriate patches in `patches/`
 
-## Upstream Source
+## Upstream source
 
 ### Rule 6: Get upstream source from upstream git repository
 
@@ -187,6 +187,6 @@ import_upstream_patches# upstream_patches
 This approach allows convenient import and maintenance of patches from upstream (e.g., cherry-picking an upstream commit on a different branch to fix a CVE).
 :::
 
-## Related Topics
+## Related topics
 
 <RelatedTopics />


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes "AI-generated phrasing". Definitions what qualifies at such phrasing [as documented](https://github.com/gardenlinux/docs-ng/blob/ae2f8301aa7673444fea3b7b794603fc951e9c31/docs/contributing/documentation/writing_good_docs.md#ai-generated-phrasing-to-avoid).
The removal of the phrases was done via the [documentation-humanize workflow](https://github.com/gardenlinux/agent-skills/blob/b4681613ef763884f4e80d4ffb29649d160121a5/workflows/documentation-humanize.md) and [skill](https://github.com/gardenlinux/agent-skills/blob/b4681613ef763884f4e80d4ffb29649d160121a5/skills/documentation-humanize/SKILL.md).