### PR TITLE
feat: remove migration frontmatter as migration is done

### DIFF
--- a/docs/explanation/package-sources.md
+++ b/docs/explanation/package-sources.md
@@ -18,10 +18,6 @@ related_topics:
   - /how-to/packaging/build-dependencies.md
   - /how-to/packaging/null-releases.md
   - /reference/packaging-rules.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-build
 github_source_path: docs/explanation/package-sources.md

--- a/docs/explanation/packaging.md
+++ b/docs/explanation/packaging.md
@@ -18,10 +18,6 @@ related_topics:
   - /how-to/packaging/build-dependencies.md
   - /how-to/packaging/null-releases.md
   - /reference/packaging-rules.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-build
 github_source_path: docs/explanation/packaging.md

--- a/docs/how-to/backporting.md
+++ b/docs/how-to/backporting.md
@@ -18,10 +18,6 @@ related_topics:
   - /how-to/packaging/build-dependencies.md
   - /how-to/packaging/null-releases.md
   - /reference/packaging-rules.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-build
 github_source_path: docs/how-to/backporting.md

--- a/docs/how-to/build-dependencies.md
+++ b/docs/how-to/build-dependencies.md
@@ -18,10 +18,6 @@ related_topics:
   - /how-to/packaging/build-dependencies.md
   - /how-to/packaging/null-releases.md
   - /reference/packaging-rules.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-build
 github_source_path: docs/how-to/build-dependencies.md

--- a/docs/how-to/creating-packages.md
+++ b/docs/how-to/creating-packages.md
@@ -18,10 +18,6 @@ related_topics:
   - /how-to/packaging/build-dependencies.md
   - /how-to/packaging/null-releases.md
   - /reference/packaging-rules.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-build
 github_source_path: docs/how-to/creating-packages.md

--- a/docs/how-to/github-actions.md
+++ b/docs/how-to/github-actions.md
@@ -18,10 +18,6 @@ related_topics:
   - /how-to/packaging/build-dependencies.md
   - /how-to/packaging/null-releases.md
   - /reference/packaging-rules.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-build
 github_source_path: docs/how-to/github-actions.md

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -17,10 +17,6 @@ related_topics:
   - /how-to/packaging/build-dependencies.md
   - /how-to/packaging/null-releases.md
   - /reference/packaging-rules.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-build
 github_source_path: docs/how-to/index.md

--- a/docs/how-to/local-build.md
+++ b/docs/how-to/local-build.md
@@ -18,10 +18,6 @@ related_topics:
   - /how-to/packaging/build-dependencies.md
   - /how-to/packaging/null-releases.md
   - /reference/packaging-rules.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-build
 github_source_path: docs/how-to/local-build.md

--- a/docs/how-to/null-releases.md
+++ b/docs/how-to/null-releases.md
@@ -18,10 +18,6 @@ related_topics:
   - /how-to/packaging/build-dependencies.md
   - /how-to/packaging/null-releases.md
   - /reference/packaging-rules.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-build
 github_source_path: docs/how-to/null-releases.md

--- a/docs/how-to/package-releases.md
+++ b/docs/how-to/package-releases.md
@@ -18,10 +18,6 @@ related_topics:
   - /how-to/packaging/build-dependencies.md
   - /how-to/packaging/null-releases.md
   - /reference/packaging-rules.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: gardenlinux
 github_source_path: docs/how-to/package-releases.md

--- a/docs/how-to/patching.md
+++ b/docs/how-to/patching.md
@@ -14,10 +14,6 @@ related_topics:
   - /how-to/packaging/build-dependencies.md
   - /how-to/packaging/null-releases.md
   - /reference/packaging-rules.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-build
 github_source_path: docs/how-to/patching.md

--- a/docs/how-to/remove-packages.md
+++ b/docs/how-to/remove-packages.md
@@ -18,10 +18,6 @@ related_topics:
   - /how-to/packaging/build-dependencies.md
   - /how-to/packaging/null-releases.md
   - /reference/packaging-rules.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-build
 github_source_path: docs/how-to/remove-packages.md

--- a/docs/reference/packaging-rules.md
+++ b/docs/reference/packaging-rules.md
@@ -17,10 +17,6 @@ related_topics:
   - /how-to/packaging/build-dependencies.md
   - /how-to/packaging/null-releases.md
   - /reference/packaging-rules.md
-migration_status: "done"
-migration_issue: "https://github.com/gardenlinux/gardenlinux/issues/4705"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: package-build
 github_source_path: docs/reference/packaging-rules.md


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/gardenlinux/gardenlinux/issues/4332 we used migration markers in the frontmatter to track the migration status. These can now be removed as the documentation system is live.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/5048
