### PR TITLE
Properly create .container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,7 @@ jobs:
           if [ ! -e .container ]; then
             image="ghcr.io/gardenlinux/repo-debian-snapshot"
             podman pull "$image"
-            digest="$(podman image inspect --format '{{ .Digest }}' "$image")"
-            echo "$image@$digest" > .container
+            podman image inspect --format='{{index .RepoDigests 0}}' "$image" > .container
           fi
       - name: set release version suffix
         if: inputs.release


### PR DESCRIPTION
**What this PR does / why we need it**:
Lately the .container file contains an image for the amd64 arch and this breaks the builds on arm64. This happens because by default the image that gets pulled matches the arch of the system.
This change is going to fix this problem by storing the image with the proper digest pointing to the multi arch image.

**Which issue(s) this PR fixes**:
Fixes #
